### PR TITLE
Fix various bugs where checks were missing for the presence of data/p…

### DIFF
--- a/rho/clicommands.py
+++ b/rho/clicommands.py
@@ -822,6 +822,10 @@ class ProfileClearCommand(CliCommand):
 
         # removes all inventories ever.
         elif self.options.all:
+            if not os.path.isfile('data/profiles'):
+                print(_("All network profiles removed"))
+                sys.exit(0)
+
             os.remove('data/profiles')
             for file_list in glob.glob("data/*_hosts"):
                 os.remove(file_list)

--- a/rho/clicommands.py
+++ b/rho/clicommands.py
@@ -266,7 +266,8 @@ def _create_ping_inventory(profile_ranges, profile_auth_list, forks):
 
         out = out.split('\n')
 
-        for line in enumerate(out):
+        # pylint: disable=consider-using-enumerate
+        for line in range(len(out)):
             if 'pong' in out[line]:
                 tup_auth_item = tuple(auth_item)
                 success_auths.add(tup_auth_item)
@@ -433,7 +434,8 @@ class ScanCommand(CliCommand):
 
         self.parser.add_option("--facts", dest="facts", metavar="FACTS",
                                action="callback", callback=multi_arg,
-                               default=[], help=_("'default' or list"))
+                               default=[], help=_("'default' or list " +
+                                                  " - REQUIRED"))
 
         self.parser.add_option("--ansible_forks", dest="ansible_forks",
                                metavar="FORKS",
@@ -606,6 +608,9 @@ class ProfileListCommand(CliCommand):
         CliCommand.__init__(self, "profile list", usage, shortdesc, desc)
 
     def _do_command(self):
+        if not os.path.isfile('data/profiles'):
+            print(_('No profiles exist yet.'))
+            sys.exit(1)
 
         with open('data/profiles', 'r') as profiles_file:
             lines = profiles_file.readlines()
@@ -674,6 +679,13 @@ class ProfileEditCommand(CliCommand):
         # understands.
 
             _check_range_validity(range_list)
+        if not os.path.isfile('data/profiles'):
+            print(_('No profiles exist yet.'))
+            sys.exit(1)
+
+        if not os.path.isfile('data/credentials'):
+            print(_('No credentials exist yet.'))
+            sys.exit(1)
 
         with open('data/profiles', 'r') as profiles_file:
             lines = profiles_file.readlines()
@@ -831,7 +843,7 @@ class ProfileAddCommand(CliCommand):
     """
 
     def __init__(self):
-        usage = _("usage: %prof profile add [options]")
+        usage = _("usage: %prog profile add [options]")
         shortdesc = _("add a network profile")
         desc = _("add a network profile")
 
@@ -896,6 +908,10 @@ class ProfileAddCommand(CliCommand):
         for auth in self.options.auth:
             for auth_item in auth.strip().split(","):
                 valid = False
+                if not os.path.isfile('data/credentials'):
+                    print(_('No credentials exist yet.'))
+                    sys.exit(1)
+
                 with open('data/credentials', 'r') as credentials_file:
                     lines = credentials_file.readlines()
                     for line in lines:
@@ -1045,6 +1061,7 @@ class AuthClearCommand(CliCommand):
                 os.remove('data/credentials')
             if os.path.isfile('data/cred-temp'):
                 os.remove('data/cred-temp')
+            print(_("All authorization credentials removed"))
 
 
 class AuthShowCommand(CliCommand):

--- a/rho/clicommands.py
+++ b/rho/clicommands.py
@@ -266,8 +266,7 @@ def _create_ping_inventory(profile_ranges, profile_auth_list, forks):
 
         out = out.split('\n')
 
-        # pylint: disable=consider-using-enumerate
-        for line in range(len(out)):
+        for line, _ in enumerate(out):
             if 'pong' in out[line]:
                 tup_auth_item = tuple(auth_item)
                 success_auths.add(tup_auth_item)

--- a/rho/clicommands.py
+++ b/rho/clicommands.py
@@ -824,19 +824,18 @@ class ProfileClearCommand(CliCommand):
         elif self.options.all:
             if not os.path.isfile('data/profiles'):
                 print(_("All network profiles removed"))
-                sys.exit(0)
+            else:
+                os.remove('data/profiles')
+                for file_list in glob.glob("data/*_hosts"):
+                    os.remove(file_list)
+                    profile = file_list.strip('_hosts')
+                    profile_mapping = 'data/' + profile + '_host_auth_mapping'
+                    if os.path.isfile(profile_mapping):
+                        os.rename(profile_mapping,
+                                  'data/(DELETED PROFILE)' +
+                                  profile + '_host_auth_mapping')
 
-            os.remove('data/profiles')
-            for file_list in glob.glob("data/*_hosts"):
-                os.remove(file_list)
-                profile = file_list.strip('_hosts')
-                profile_mapping = 'data/' + profile + '_host_auth_mapping'
-                if os.path.isfile(profile_mapping):
-                    os.rename(profile_mapping,
-                              'data/(DELETED PROFILE)' +
-                              profile + '_host_auth_mapping')
-
-            print(_("All network profiles removed"))
+                print(_("All network profiles removed"))
 
 
 class ProfileAddCommand(CliCommand):

--- a/test/test_clicommand.py
+++ b/test/test_clicommand.py
@@ -15,7 +15,8 @@
 
 import unittest
 import sys
-from rho.clicommands import AuthListCommand, ProfileAddCommand, \
+from rho.clicommands import AuthAddCommand, AuthListCommand, \
+    AuthClearCommand, ProfileAddCommand, ProfileClearCommand, \
     ProfileListCommand, ScanCommand
 
 
@@ -132,3 +133,23 @@ class CliCommandsTests(unittest.TestCase):
                            "profilename", "hosts",
                            "a:d:b:s", "--auths",
                            "auth_1", "auth2"])
+
+    def test_a_auth_add(self):
+        """Testing the auth clear all command execution"""
+        self._run_test(AuthAddCommand(), ["auth", "add", "--name", "auth1",
+                                          "--username", "user", "--sshkeyfile",
+                                          "./privatekey"])
+
+    def test_a_profile_add(self):
+        """Testing the auth clear all command execution"""
+        self._run_test(ProfileAddCommand(), ["profile", "add", "--name", "p1",
+                                             "--hosts", "1.2.3.4",
+                                             "--auth", "auth1"])
+
+    def test_z_auth_clear_all(self):
+        """Testing the auth clear all command execution"""
+        self._run_test(AuthClearCommand(), ["auth", "clear", "--all"])
+
+    def test_z_profile_clear_all(self):
+        """Testing the profile clear all command execution"""
+        self._run_test(ProfileClearCommand(), ["profile", "clear", "--all"])


### PR DESCRIPTION
…rofiles or data/credentials. Closes #15.

Fix various bugs while playing with rho command line vagrant functional testing.
```
~/Code/rho$ rho profile clear --all
All network profiles removed
~/Code/rho$ rho auth clear --all
All authorization credentials removed
#Test profile creation without auth existing
~/Code/rho$ rho profile add --name=vagrant-local --hosts 127.0.0.1:2222 --auth rho-dev_auth
No credentials exist yet.
#create auth
~/Code/rho$ rho auth add --name=rho-dev_auth --sshkeyfile=./.vagrant/machines/rho-dev/virtualbox/private_key --username=vagrant
~/Code/rho$ rho profile add --name=vagrant-local --hosts 127.0.0.1:2222 --auth rho-dev_auth
#Edit profile with non-existent auth
~/Code/rho$ rho profile edit --name=vagrant-local --hosts 127.0.0.1:2222 --auth test_1_auth
Auths do not exist.
```
