### PR TITLE
Use Ansible variables, not dynamic role files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@ build
 .build
 test/coverage
 data
-roles
 
 .vagrant
 *.retry

--- a/library/run_cmds.py
+++ b/library/run_cmds.py
@@ -23,8 +23,6 @@ import xml
 import ast
 import re
 from ansible.module_utils.basic import AnsibleModule
-
-print "PYTHONPATH:", sys.path
 from ansible.module_utils import rho_cmd
 
 if sys.version_info > (3,):
@@ -38,7 +36,6 @@ else:
 
 T = gettext.translation('rho', 'locale', fallback=True)
 _ = T.ugettext
-
 
 
 class DateRhoCmd(rho_cmd.RhoCmd):
@@ -1172,9 +1169,9 @@ class RunCommands(object):
         # Goes through all the default commands
         # and executes them on the box's shell
         info_dict = {}
-        for rho_cmd in self.facts_requested:
-            rcmd = rho_cmd()
-            rcmd.run_cmd(self.facts_requested[rho_cmd])
+        for command in self.facts_requested:
+            rcmd = command()
+            rcmd.run_cmd(self.facts_requested[command])
             info_dict.update(rcmd.data)
 
         if 'all' not in self.facts_requested.values():

--- a/module_utils/rho_cmd.py
+++ b/module_utils/rho_cmd.py
@@ -11,6 +11,7 @@ import subprocess as sp
 
 PRINT_LOG = ""
 
+
 class RhoCmd(object):
     """RhoCmd and its sub-classes are wrapper classes around
     the cli cmds we run on the host machines. The

--- a/rho/clicommands.py
+++ b/rho/clicommands.py
@@ -21,6 +21,7 @@ import uuid
 import re
 import glob
 import time
+import json
 import subprocess as sp
 from collections import defaultdict
 from collections import OrderedDict
@@ -138,73 +139,6 @@ def _check_range_validity(range_list):
                 print(_("No such hosts file."))
             print(_("Bad host name/range : '%s'") % reg_item)
             sys.exit(1)
-
-
-# Function to write to the playbook. Takes in the facts
-# requested by the user and the file path for the report.
-def _edit_playbook(facts, report_path):
-    string_to_write = "---\n\n- name: Collect these facts\n" \
-                      "  run_cmds: name=whatever fact_names=default\n" \
-                      "  register: facts_all\n\n" \
-                      "- name: record host returned dictionary\n" \
-                      "  set_fact:\n    res={{facts_all.meta}}\n"
-    # pylint: disable=unidiomatic-typecheck
-    if os.path.isfile(facts[0]) and not facts == ['default']:
-        my_facts = _read_in_file(facts[0])
-        string_to_write = "---\n\n- name: Collect these facts\n" \
-                          "  set_fact:\n    fact_list:\n"
-        string_to_write = _stringify_facts(string_to_write, my_facts)
-    elif type(facts) == list and len(facts) >= 1 and\
-            not facts == ['default']:
-        string_to_write = "---\n\n- name: Collect these facts\n" \
-                          "  set_fact:\n    fact_list:\n"
-        string_to_write = _stringify_facts(string_to_write, facts)
-    elif not facts == ['default']:
-        print(_("facts can be a file, list or 'default' only"))
-        sys.exit(1)
-
-    report_path = os.path.abspath(os.path.normpath(report_path))
-
-    if not os.path.exists('roles/collect/tasks'):
-        os.makedirs('roles/collect/tasks')
-
-    with open('roles/collect/tasks/main.yml', 'w') as collect_task_file:
-        collect_task_file.write(string_to_write)
-
-    string_to_write = '---\n\n- name: store facts from all' \
-                      ' hosts in a variable\n  set_fact: ' \
-                      'host_fact={{hostvars[item]["res"]}}\n ' \
-                      ' with_items: "{{groups.alpha}}"\n ' \
-                      ' register: host_facts\n\n- name:' \
-                      ' parse variable into a list of dictionaries' \
-                      '\n  set_fact: host_facts="{{ host_facts.results' \
-                      ' | map(attribute="ansible_facts.host_fact") | list }}' \
-                      '"\n\n- name: write the list to a csv\n  spit_results:' \
-                      ' name=spit file_path=' + report_path + ' vals' \
-                                                              '={{host_' \
-                                                              'facts}}\n'
-
-    if not os.path.exists('roles/write/tasks'):
-        os.makedirs('roles/write/tasks')
-    with open('roles/write/tasks/main.yml', 'w') as write_task_file:
-        write_task_file.write(string_to_write)
-
-
-# Helper function to fill in the collect role
-# of the playbook.
-def _stringify_facts(string_to_write, facts):
-    for fact in facts:
-        string_to_write += "      - " + fact + "\n"
-
-    string_to_write += "\n- name: grab info from list\n" \
-                       "  run_cmds: name=list_facts fact_names" \
-                       "={{fact_list}}\n" \
-                       "  register: facts_selected\n\n" \
-                       "- name: record host returned dictionary\n" \
-                       "  set_fact:\n" \
-                       "    res={{facts_selected.meta}}\n"
-
-    return string_to_write
 
 
 # Creates the inventory for pinging all hosts and records
@@ -497,7 +431,8 @@ class ScanCommand(CliCommand):
         forks = self.options.ansible_forks \
             if self.options.ansible_forks else '50'
 
-        report_path = self.options.report_path
+        report_path = os.path.abspath(os.path.normpath(
+            self.options.report_path))
 
         profile_exists = False
 
@@ -536,8 +471,6 @@ class ScanCommand(CliCommand):
             print(_("Invalid profile. Create profile first"))
             sys.exit(1)
 
-        _edit_playbook(facts, report_path)
-
         # reset is used when the profile has just been created
         # or freshly updated.
 
@@ -563,11 +496,28 @@ class ScanCommand(CliCommand):
                   "Please use --reset with profile first.")
             sys.exit(1)
 
-        cmd_string = 'ansible-playbook rho_playbook.yml -i data/'\
-                     + profile + '_hosts ' + '-v -f ' + forks
+        if facts == ['default']:
+            facts_to_collect = 'default'
+        elif os.path.isfile(facts[0]):
+            facts_to_collect = _read_in_file(facts[0])
+        else:
+            assert isinstance(facts, list)
+            facts_to_collect = facts
+
+        ansible_vars = {'facts_to_collect': facts_to_collect,
+                        'report_path': report_path}
+
+        cmd_string = ('ansible-playbook rho_playbook.yml '
+                      '-i data/{profile}_hosts -v -f {forks} '
+                      '--extra-vars \'{vars}\'').format(
+                          profile=profile,
+                          forks=forks,
+                          vars=json.dumps(ansible_vars))
 
         # process finally runs ansible on the
         # playbook and inventories thus created.
+
+        print ('Running:', cmd_string)
 
         process = sp.Popen(cmd_string,
                            shell=True)

--- a/roles/collect/tasks/main.yml
+++ b/roles/collect/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+
+- name: Collect these facts
+  run_cmds: name=whatever fact_names={{facts_to_collect}}
+  register: facts_all
+
+- name: record host returned dictionary
+  set_fact:
+    res={{facts_all.meta}}

--- a/roles/write/tasks/main.yml
+++ b/roles/write/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+
+- name: store facts from all hosts in a variable
+  set_fact: host_fact={{hostvars[item]["res"]}}
+  with_items: "{{groups.alpha}}"
+  register: host_facts
+
+- name: parse variable into a list of dictionaries
+  set_fact: host_facts="{{ host_facts.results | map(attribute="ansible_facts.host_fact") | list }}"
+
+- name: write the list to a csv
+  spit_results: name=spit file_path={{report_path}} vals={{host_facts}}


### PR DESCRIPTION
Don't dynamically generate the Ansible role files

Fix an issue I ran into while I was working on JBoss Scanner integration. Moving the the Ansible role files out of the Python code makes it much easier to add new tasks, which we will want to do when we integrate JBoss Scanner.