### PR TITLE
Move config paths to rho.utilities

### DIFF
--- a/rho/authaddcommand.py
+++ b/rho/authaddcommand.py
@@ -20,6 +20,7 @@ import sys
 import uuid
 from getpass import getpass
 from collections import OrderedDict
+from rho import utilities
 from rho.clicommand import CliCommand
 from rho.vault import get_vault
 from rho.translation import get_translation
@@ -48,13 +49,10 @@ def _save_cred(vault, new_cred, cred_list):
     :param cred_list: A list of existing credential dictionaries from the
     credential file
     """
-    credentials_path = 'data/credentials'
 
-    if not os.path.exists('data'):
-        os.makedirs('data')
-
+    utilities.ensure_config_dir_exists()
     cred_list.append(new_cred)
-    vault.dump_as_json_to_file(cred_list, credentials_path)
+    vault.dump_as_json_to_file(cred_list, utilities.CREDENTIALS_PATH)
 
 
 class AuthAddCommand(CliCommand):
@@ -107,12 +105,11 @@ class AuthAddCommand(CliCommand):
         cred = {}
         ssh_file = 'empty'
         pass_to_store = ''
-        credentials_path = 'data/credentials'
         auth_name = self.options.name
         cred_list = []
 
-        if os.path.isfile(credentials_path):
-            cred_list = vault.load_as_json(credentials_path)
+        if os.path.isfile(utilities.CREDENTIALS_PATH):
+            cred_list = vault.load_as_json(utilities.CREDENTIALS_PATH)
             auth_found = auth_exists(cred_list, auth_name)
             if auth_found:
                 print(_("Auth with name exists"))

--- a/rho/authclearcommand.py
+++ b/rho/authclearcommand.py
@@ -17,6 +17,7 @@ existing authentication credentials.
 from __future__ import print_function
 import os
 import sys
+from rho import utilities
 from rho.clicommand import CliCommand
 from rho.vault import get_vault
 from rho.translation import get_translation
@@ -58,20 +59,19 @@ class AuthClearCommand(CliCommand):
             sys.exit(1)
 
     def _do_command(self):
-        credentials_path = 'data/credentials'
-
         if self.options.name:
             vault = get_vault(self.options.vaultfile)
-            if os.path.isfile(credentials_path):
-                cred_list = vault.load_as_json(credentials_path)
+            if os.path.isfile(utilities.CREDENTIALS_PATH):
+                cred_list = vault.load_as_json(utilities.CREDENTIALS_PATH)
                 for index, cred in enumerate(cred_list):
                     if cred.get('name') == self.options.name:
                         del cred_list[index]
                         break
-                vault.dump_as_json_to_file(cred_list, credentials_path)
+                vault.dump_as_json_to_file(
+                    cred_list, utilities.CREDENTIALS_PATH)
 
         elif self.options.all:
-            if os.path.isfile(credentials_path):
-                os.remove(credentials_path)
+            if os.path.isfile(utilities.CREDENTIALS_PATH):
+                os.remove(utilities.CREDENTIALS_PATH)
 
             print(_("All authorization credentials removed"))

--- a/rho/autheditcommand.py
+++ b/rho/autheditcommand.py
@@ -18,6 +18,7 @@ from __future__ import print_function
 import sys
 import os
 from getpass import getpass
+from rho import utilities
 from rho.clicommand import CliCommand
 from rho.vault import get_vault
 from rho.translation import get_translation
@@ -100,13 +101,12 @@ class AuthEditCommand(CliCommand):
 
     def _do_command(self):
         vault = get_vault(self.options.vaultfile)
-        credentials_path = 'data/credentials'
         auth_found = False
 
-        if not os.path.isfile(credentials_path):
+        if not os.path.isfile(utilities.CREDENTIALS_PATH):
             print(_("No auth credentials found"))
         else:
-            cred_list = vault.load_as_json(credentials_path)
+            cred_list = vault.load_as_json(utilities.CREDENTIALS_PATH)
 
             for cred in cred_list:
                 if cred.get('name') == self.options.name:
@@ -122,6 +122,6 @@ class AuthEditCommand(CliCommand):
                 print(_('Auth "%s" does not exist' % self.options.name))
                 sys.exit(1)
 
-            vault.dump_as_json_to_file(cred_list, credentials_path)
+            vault.dump_as_json_to_file(cred_list, utilities.CREDENTIALS_PATH)
 
         print(_("Auth '%s' updated") % self.options.name)

--- a/rho/authlistcommand.py
+++ b/rho/authlistcommand.py
@@ -17,6 +17,7 @@ for system access
 from __future__ import print_function
 import os
 import sys
+from rho import utilities
 from rho.clicommand import CliCommand
 from rho.vault import get_vault
 from rho.translation import get_translation
@@ -42,13 +43,12 @@ class AuthListCommand(CliCommand):
 
     def _do_command(self):
         vault = get_vault(self.options.vaultfile)
-        credentials_path = 'data/credentials'
 
-        if not os.path.isfile(credentials_path):
+        if not os.path.isfile(utilities.CREDENTIALS_PATH):
             print(_('No credentials exist yet.'))
             sys.exit(1)
 
-        cred_list = vault.load_as_json(credentials_path)
+        cred_list = vault.load_as_json(utilities.CREDENTIALS_PATH)
 
         for cred in cred_list:
             output = cred.get('id') + ','

--- a/rho/authshowcommand.py
+++ b/rho/authshowcommand.py
@@ -16,6 +16,7 @@
 from __future__ import print_function
 import os
 import sys
+from rho import utilities
 from rho.clicommand import CliCommand
 from rho.vault import get_vault
 from rho.translation import get_translation
@@ -52,12 +53,11 @@ class AuthShowCommand(CliCommand):
 
     def _do_command(self):
         vault = get_vault(self.options.vaultfile)
-        credentials_path = 'data/credentials'
         auth_found = False
-        if not os.path.isfile(credentials_path):
+        if not os.path.isfile(utilities.CREDENTIALS_PATH):
             print(_("No auth credentials found"))
         else:
-            cred_list = vault.load_as_json(credentials_path)
+            cred_list = vault.load_as_json(utilities.CREDENTIALS_PATH)
 
             for cred in cred_list:
                 if cred.get('name') == self.options.name:

--- a/rho/profileaddcommand.py
+++ b/rho/profileaddcommand.py
@@ -48,14 +48,12 @@ def _save_profile(vault, new_profile, profiles_list):
     :param profiles_list: A list of existing profiles dictionaries from the
     profiles file
     """
-    profiles_path = 'data/profiles'
 
-    if not os.path.exists('data'):
-        os.makedirs('data')
+    utilities.ensure_config_dir_exists()
 
     profiles_list.append(new_profile)
 
-    vault.dump_as_json_to_file(profiles_list, profiles_path)
+    vault.dump_as_json_to_file(profiles_list, utilities.PROFILES_PATH)
 
 
 class ProfileAddCommand(CliCommand):
@@ -108,17 +106,15 @@ class ProfileAddCommand(CliCommand):
     def _do_command(self):
         vault = get_vault(self.options.vaultfile)
         hosts_list = self.options.hosts
-        profiles_path = 'data/profiles'
         profiles_list = []
-        credentials_path = 'data/credentials'
         ssh_port = 22
 
         if hasattr(self.options, 'sshport') \
            and self.options.sshport is not None:
             ssh_port = utilities.validate_port(self.options.sshport)
 
-        if os.path.isfile(profiles_path):
-            profiles_list = vault.load_as_json(profiles_path)
+        if os.path.isfile(utilities.PROFILES_PATH):
+            profiles_list = vault.load_as_json(utilities.PROFILES_PATH)
             profile_found = profile_exists(profiles_list, self.options.name)
             if profile_found:
                 print(_("Profile '%s' already exists.") % self.options.name)
@@ -132,12 +128,12 @@ class ProfileAddCommand(CliCommand):
 
         _check_range_validity(range_list)
 
-        if not os.path.isfile(credentials_path):
+        if not os.path.isfile(utilities.CREDENTIALS_PATH):
             print(_('No credentials exist yet.'))
             sys.exit(1)
 
         creds = []
-        cred_list = vault.load_as_json(credentials_path)
+        cred_list = vault.load_as_json(utilities.CREDENTIALS_PATH)
         for auth in self.options.auth:
             for auth_item in auth.strip().split(","):
                 valid = False

--- a/rho/profileclearcommand.py
+++ b/rho/profileclearcommand.py
@@ -18,6 +18,7 @@ from __future__ import print_function
 import os
 import sys
 import glob
+from rho import utilities
 from rho.clicommand import CliCommand
 from rho.vault import get_vault
 from rho.translation import get_translation
@@ -63,13 +64,12 @@ class ProfileClearCommand(CliCommand):
 
     # pylint: disable=too-many-branches
     def _do_command(self):
-        profiles_path = 'data/profiles'
         profiles_list = []
 
         if self.options.name:
             vault = get_vault(self.options.vaultfile)
             profile = self.options.name
-            profiles_list = vault.load_as_json(profiles_path)
+            profiles_list = vault.load_as_json(utilities.PROFILES_PATH)
             profile_found = False
 
             for index, curr_profile in enumerate(profiles_list):
@@ -82,7 +82,7 @@ class ProfileClearCommand(CliCommand):
                 print(_("No such profile: '%s'") % profile)
                 sys.exit(1)
 
-            vault.dump_as_json_to_file(profiles_list, profiles_path)
+            vault.dump_as_json_to_file(profiles_list, utilities.PROFILES_PATH)
 
             # removes inventory associated with the profile
             if os.path.isfile('data/' + profile + "_hosts"):
@@ -102,10 +102,10 @@ class ProfileClearCommand(CliCommand):
 
         # removes all inventories ever.
         elif self.options.all:
-            if not os.path.isfile(profiles_path):
+            if not os.path.isfile(utilities.PROFILES_PATH):
                 print(_("All network profiles removed"))
             else:
-                os.remove(profiles_path)
+                os.remove(utilities.PROFILES_PATH)
                 for file_list in glob.glob("data/*_hosts"):
                     os.remove(file_list)
                     profile = file_list.strip('_hosts')

--- a/rho/profileeditcommand.py
+++ b/rho/profileeditcommand.py
@@ -77,24 +77,22 @@ class ProfileEditCommand(CliCommand):
         # pylint: disable=too-many-locals, too-many-branches
         # pylint: disable=too-many-statements, too-many-nested-blocks
         vault = get_vault(self.options.vaultfile)
-        profiles_path = 'data/profiles'
-        credentials_path = 'data/credentials'
         cred_list = []
         profiles_list = []
         range_list = []
         profile_found = False
         auth_found = False
 
-        if not os.path.isfile(credentials_path):
+        if not os.path.isfile(utilities.CREDENTIALS_PATH):
             print(_('No credentials exist yet.'))
             sys.exit(1)
 
-        if not os.path.isfile(profiles_path):
+        if not os.path.isfile(utilities.PROFILES_PATH):
             print(_('No profiles exist yet.'))
             sys.exit(1)
 
-        cred_list = vault.load_as_json(credentials_path)
-        profiles_list = vault.load_as_json(profiles_path)
+        cred_list = vault.load_as_json(utilities.CREDENTIALS_PATH)
+        profiles_list = vault.load_as_json(utilities.PROFILES_PATH)
 
         if self.options.hosts:
             hosts_list = self.options.hosts
@@ -138,5 +136,5 @@ class ProfileEditCommand(CliCommand):
             print(_("Profile '%s' does not exist.") % self.options.name)
             sys.exit(1)
 
-        vault.dump_as_json_to_file(profiles_list, profiles_path)
+        vault.dump_as_json_to_file(profiles_list, utilities.PROFILES_PATH)
         print(_("Profile '%s' edited" % self.options.name))

--- a/rho/profilelistcommand.py
+++ b/rho/profilelistcommand.py
@@ -18,6 +18,7 @@ from __future__ import print_function
 import os
 import sys
 import json
+from rho import utilities
 from rho.clicommand import CliCommand
 from rho.vault import get_vault
 from rho.translation import get_translation
@@ -43,13 +44,12 @@ class ProfileListCommand(CliCommand):
 
     def _do_command(self):
         vault = get_vault(self.options.vaultfile)
-        profiles_path = 'data/profiles'
 
-        if not os.path.isfile(profiles_path):
+        if not os.path.isfile(utilities.PROFILES_PATH):
             print(_('No profiles exist yet.'))
             sys.exit(1)
 
-        profiles_list = vault.load_as_json(profiles_path)
+        profiles_list = vault.load_as_json(utilities.PROFILES_PATH)
         data = json.dumps(profiles_list, sort_keys=True, indent=4,
                           separators=(',', ': '))
         print(data)

--- a/rho/profileshowcommand.py
+++ b/rho/profileshowcommand.py
@@ -18,6 +18,7 @@ from __future__ import print_function
 import sys
 import os
 import json
+from rho import utilities
 from rho.clicommand import CliCommand
 from rho.vault import get_vault
 from rho.translation import get_translation
@@ -55,14 +56,13 @@ class ProfileShowCommand(CliCommand):
 
     def _do_command(self):
         vault = get_vault(self.options.vaultfile)
-        profiles_path = 'data/profiles'
 
-        if not os.path.isfile(profiles_path):
+        if not os.path.isfile(utilities.PROFILES_PATH):
             print(_('No profiles exist yet.'))
             sys.exit(1)
 
         profile_found = False
-        profiles_list = vault.load_as_json(profiles_path)
+        profiles_list = vault.load_as_json(utilities.PROFILES_PATH)
         for profile in profiles_list:
             if self.options.name == profile.get('name'):
                 profile_found = True

--- a/rho/scancommand.py
+++ b/rho/scancommand.py
@@ -20,6 +20,7 @@ import time
 import json
 from collections import defaultdict
 import pexpect
+from rho import utilities
 from rho.clicommand import CliCommand
 from rho.vault import get_vault_and_password
 from rho.utilities import multi_arg, _read_in_file, str_to_ascii
@@ -289,8 +290,6 @@ class ScanCommand(CliCommand):
         # pylint: disable=too-many-locals
         # pylint: disable=too-many-branches
         vault, vault_pass = get_vault_and_password(self.options.vaultfile)
-        profiles_path = 'data/profiles'
-        credentials_path = 'data/credentials'
         profile_found = False
         profile_auth_list = []
         profile_ranges = []
@@ -304,22 +303,22 @@ class ScanCommand(CliCommand):
 
         # Checks if profile exists and stores information
         # about that profile for later use.
-        if not os.path.isfile(profiles_path):
+        if not os.path.isfile(utilities.PROFILES_PATH):
             print(_('No profiles exist yet.'))
             sys.exit(1)
 
-        if not os.path.isfile(credentials_path):
+        if not os.path.isfile(utilities.CREDENTIALS_PATH):
             print(_('No auth credentials exist yet.'))
             sys.exit(1)
 
-        profiles_list = vault.load_as_json(profiles_path)
+        profiles_list = vault.load_as_json(utilities.PROFILES_PATH)
         for curr_profile in profiles_list:
             if self.options.profile == curr_profile.get('name'):
                 profile_found = True
                 profile_ranges = curr_profile.get('hosts')
                 profile_auths = curr_profile.get('auth')
                 profile_port = curr_profile.get('ssh_port')
-                cred_list = vault.load_as_json(credentials_path)
+                cred_list = vault.load_as_json(utilities.CREDENTIALS_PATH)
                 for auth in profile_auths:
                     for cred in cred_list:
                         if auth.get('id') == cred.get('id'):

--- a/rho/utilities.py
+++ b/rho/utilities.py
@@ -16,6 +16,17 @@ import sys
 import re
 from rho.translation import get_translation
 
+CREDENTIALS_PATH = 'data/credentials'
+PROFILES_PATH = 'data/profiles'
+
+
+def ensure_config_dir_exists():
+    """Ensure the Rho configuration directory exists."""
+
+    if not os.path.exists('data'):
+        os.makedirs('data')
+
+
 _ = get_translation()
 
 


### PR DESCRIPTION
Having the paths to configuration files in a central location will
make it possible to temporarily change them to something else for
testing.