### PR TITLE
Provide missing connection information host and port. Closes #79.

### DIFF
--- a/doc/command_syntax_usage.rst
+++ b/doc/command_syntax_usage.rst
@@ -73,6 +73,9 @@ Output
 The important part about a scan is the results report. By default,
 this contains a large amount of information about the operating system, hardware, and platform.
 
+
+- ``connection.host`` - The host address of the connection
+- ``connection.port`` - The port used for the connection
 - ``cpu.bogomips`` - measurement of CPU speed made by the Linux kernel
 - ``cpu.count`` - number of processors
 - ``cpu.cpu_family`` - cpu family
@@ -93,7 +96,7 @@ this contains a large amount of information about the operating system, hardware
 - ``etc-release.name`` - name of the release
 - ``etc-release.release`` - release information
 - ``etc-release.version`` - release version
-- ``instnum.instnum`` installation number
+- ``instnum.instnum`` - installation number
 - ``redhat-packages.is_redhat`` - determines if package is a Red Hat package
 - ``redhat-packages.last_installed`` - last installed package
 - ``redhat-packages.last_built`` - last built package

--- a/library/run_cmds.py
+++ b/library/run_cmds.py
@@ -77,6 +77,8 @@ class RunCommands(object):
     def __init__(self, module):
         self.name = module.params["name"]
         self.facts_requested = {}
+        self.host = module.params["host"]
+        self.port = module.params["port"]
 
         # exception used to see if the input from playbook
         # is a list of facts or just a string so that
@@ -153,6 +155,8 @@ class RunCommands(object):
                     if k not in facts_requested_list:
                         info_dict.pop(k, None)
 
+        info_dict['connection.host'] = self.host
+        info_dict['connection.port'] = self.port
         return info_dict
 
 
@@ -161,7 +165,9 @@ def main():
     from the playbook about the facts that need to be collected.
     """
     module = AnsibleModule(argument_spec=dict(name=dict(required=True),
-                                              fact_names=dict(required=False)))
+                                              fact_names=dict(required=False),
+                                              host=dict(required=True),
+                                              port=dict(required=True)))
 
     try:
         my_runner = RunCommands(module=module)

--- a/rho_playbook.yml
+++ b/rho_playbook.yml
@@ -4,20 +4,13 @@
 
 ---
 
-- name: Collect all default facts
+- name: collect all requested facts
   hosts: all
   roles:
     - collect
 
 
-- name: Write default facts first to a variable and then to csv locally
+- name: write facts first to a variable and then to csv locally
   hosts: localhost
   roles:
     - write
-
-
-
-
-
-
-

--- a/roles/collect/tasks/main.yml
+++ b/roles/collect/tasks/main.yml
@@ -1,7 +1,11 @@
 ---
 
-- name: Collect these facts
-  run_cmds: name=whatever fact_names={{facts_to_collect}}
+- name: collect requested facts
+  run_cmds:
+    name: scanner
+    fact_names: "{{facts_to_collect}}"
+    host: "{{ansible_host}}"
+    port: "{{ansible_ssh_port}}"
   register: facts_all
 
 - name: record host returned dictionary


### PR DESCRIPTION
Here is the new output that provides the connection information:
```
connection.host,connection.port,cpu.bogomips,cpu.count,cpu.cpu_family,cpu.model_name,cpu.model_ver,cpu.socket_count,cpu.vendor_id,date.anaconda_log,date.date,date.filesystem_create,date.machine_id,date.yum_history,dmi.bios-vendor,dmi.bios-version,dmi.processor-family,dmi.system-manufacturer,etc-issue.contents,etc-issue.etc-issue,etc_release.name,etc_release.release,etc_release.version,instnum.contents,instnum.instnum,redhat-packages.is_redhat,redhat-packages.last_built,redhat-packages.last_installed,redhat-packages.num_installed_packages,redhat-packages.num_rh_packages,redhat-release.name,redhat-release.release,redhat-release.version,systemid.contents,uname.all,uname.hardware_platform,uname.hostname,uname.kernel,uname.os,uname.processor,virt-what.type,virt.num_guests,virt.num_running_guests,virt.type,virt.virt
10.10.181.175,22,5400.00,2,6,Intel(R) Xeon(R) CPU E5-2697 v2 @ 2.70GHz,62,sudo: a password is required,GenuineIntel,,Mon Jul 24 15:49:27 EDT 2017,,2017-07-18,,error,error,error,error,"""\SKernel \r on an \m""","""\SKernel \r on an \m""",Red Hat Enterprise Linux Server,Red Hat Enterprise Linux Server release 7.4 (Maipo),7.4 (Maipo),"""""",,Y,selinux-policy-3.13.1-166.el7                                                 Built: Mon 10 Jul 2017 12:02:54 PM EDT,js-1.8.5-19.el7                                                 Installed: Wed 19 Jul 2017 09:24:57 AM EDT,376,376,redhat-release-server,18.el7,7.4,"""""",Linux dhcp181-175.gsslab.rdu2.redhat.com 3.10.0-693.el7.x86_64 #1 SMP Thu Jul 6 19:56:57 EDT 2017 x86_64 x86_64 x86_64 GNU/Linux,x86_64,dhcp181-175.gsslab.rdu2.redhat.com,3.10.0-693.el7.x86_64,Linux,x86_64,error,error,error,error: privcmd false,error: privcmd false
```