### PR TITLE
Add Python 3 linting to the Makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ python:
 # command to install dependencies
 install:
   - pip install -r requirements.txt
-  - pip3 install -r requirements.txt
   - pip install coveralls
 # command to run tests
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
 # command to install dependencies
 install:
   - pip install -r requirements.txt
+  - pip3 install -r requirements.txt
   - pip install coveralls
 # command to run tests
 script:

--- a/Makefile
+++ b/Makefile
@@ -36,18 +36,37 @@ install: build
 
 tests:
 	-py.test -v
-	-py.test-3 -v
 
 tests-coverage:
 	-py.test -v --cov=rho --cov=library
-	-py.test-3 -v --cov=rho --cov=library
 
 lint-flake8:
 	flake8 . --ignore D203
-	python3 -m flake8 . --ignore D203
 
 lint-pylint:
 	pylint --disable=duplicate-code */*.py
-	python3 -m pylint --disable=duplicate-code,locally-disabled */*.py -rn
 
 lint: lint-flake8 lint-pylint
+
+# Travis doesn't use the -3 prefix with Python 3 executables, so we
+# need to keep these separate from the build targets that Travis will
+# use.
+tests-3:
+	-py.test-3 -v
+
+tests-coverage-3:
+	-py.test-3 -v --cov=rho --cov=library
+
+lint-flake8-3:
+	python3 -m flake8 . --ignore D203
+
+lint-pylint-3:
+	python3 -m pylint --disable=duplicate-code,locally-disabled */*.py -rn
+
+lint-3: lint-flake8-3 lint-pylint-3
+
+# But for local testing, we want to be able to test Python 2 and 3
+# together conveniently, so we also have these targets.
+tests-all: tests tests-3
+
+lint-all: lint lint-3

--- a/Makefile
+++ b/Makefile
@@ -36,14 +36,18 @@ install: build
 
 tests:
 	-py.test -v
+	-py.test-3 -v
 
 tests-coverage:
 	-py.test -v --cov=rho --cov=library
+	-py.test-3 -v --cov=rho --cov=library
 
 lint-flake8:
 	flake8 . --ignore D203
+	python3 -m flake8 . --ignore D203
 
 lint-pylint:
 	pylint --disable=duplicate-code */*.py
+	pylint-3 --disable=duplicate-code,locally-disabled */*.py -rn
 
 lint: lint-flake8 lint-pylint

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,6 @@ lint-flake8:
 
 lint-pylint:
 	pylint --disable=duplicate-code */*.py
-	pylint-3 --disable=duplicate-code,locally-disabled */*.py -rn
+	python3 -m pylint --disable=duplicate-code,locally-disabled */*.py -rn
 
 lint: lint-flake8 lint-pylint

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -14,3 +14,6 @@ Coverage
 
 #Docs
 Sphinx
+
+# Needed for StringIO
+six

--- a/library/run_cmds.py
+++ b/library/run_cmds.py
@@ -17,7 +17,7 @@ import json
 import uuid
 
 import ast
-# pylint:disable=no-name-in-module
+# pylint:disable=no-name-in-module, import-error
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils import rho_cmd
 from ansible.module_utils import date_command
@@ -116,6 +116,7 @@ class RunCommands(object):
                     # be run to fill in all corresponding fields.
 
         elif isinstance(self.fact_names, str):
+            # pylint: disable=no-member
             if self.fact_names.lower().strip() == "default":
                 for def_cmd in DEFAULT_CMDS:
                     self.facts_requested[def_cmd] = "all"

--- a/library/spit_results.py
+++ b/library/spit_results.py
@@ -16,6 +16,7 @@
 import csv
 import os
 import json
+# pylint: disable=import-error
 from ansible.module_utils.basic import AnsibleModule
 
 

--- a/module_utils/cpu_command.py
+++ b/module_utils/cpu_command.py
@@ -9,14 +9,13 @@
 
 """Get /proc/cpuinfo information from the remote machine."""
 
-import gettext
 import re
 import subprocess as sp
 
-from ansible.module_utils import rho_cmd  # pylint:disable=no-name-in-module
+# pylint:disable=no-name-in-module, import-error
+from ansible.module_utils import rho_cmd
 
-T = gettext.translation('rho', 'locale', fallback=True)
-_ = T.ugettext
+from ansible.module_utils.translation import _
 
 
 class CpuRhoCmd(rho_cmd.RhoCmd):

--- a/module_utils/date_command.py
+++ b/module_utils/date_command.py
@@ -9,12 +9,9 @@
 
 """Get the system date, in a few different ways."""
 
-import gettext
-
-from ansible.module_utils import rho_cmd  # pylint: disable=no-name-in-module
-
-T = gettext.translation('rho', 'locale', fallback=True)
-_ = T.ugettext
+# pylint: disable=no-name-in-module, import-error
+from ansible.module_utils import rho_cmd
+from ansible.module_utils.translation import _
 
 
 # pylint: disable=too-few-public-methods

--- a/module_utils/dmi_command.py
+++ b/module_utils/dmi_command.py
@@ -9,12 +9,9 @@
 
 """Get BIOS information from the DMI."""
 
-import gettext
-
-from ansible.module_utils import rho_cmd  # pylint: disable=no-name-in-module
-
-T = gettext.translation('rho', 'locale', fallback=True)
-_ = T.ugettext
+# pylint: disable=no-name-in-module, import-error
+from ansible.module_utils import rho_cmd
+from ansible.module_utils.translation import _
 
 
 # pylint: disable=too-few-public-methods

--- a/module_utils/etc_release_command.py
+++ b/module_utils/etc_release_command.py
@@ -11,7 +11,8 @@
 
 import subprocess as sp
 
-from ansible.module_utils import rho_cmd  # pylint: disable=no-name-in-module
+# pylint: disable=no-name-in-module, import-error
+from ansible.module_utils import rho_cmd
 
 
 class EtcReleaseRhoCmd(rho_cmd.RhoCmd):

--- a/module_utils/file_commands.py
+++ b/module_utils/file_commands.py
@@ -4,18 +4,15 @@ import sys
 # for expat exceptions...
 import xml
 
-import gettext
-
-from ansible.module_utils import rho_cmd  # pylint: disable=no-name-in-module
+# pylint: disable=no-name-in-module, import-error
+from ansible.module_utils import rho_cmd
+from ansible.module_utils.translation import _
 
 # for parsing systemid
 if sys.version_info > (3,):
     import xmlrpc.client as xmlrpclib  # pylint: disable=import-error
 else:
     import xmlrpclib  # pylint: disable=import-error
-
-T = gettext.translation('rho', 'locale', fallback=True)
-_ = T.ugettext
 
 
 # pylint: disable=too-few-public-methods

--- a/module_utils/redhat_packages_command.py
+++ b/module_utils/redhat_packages_command.py
@@ -11,7 +11,8 @@
 
 import sys
 
-from ansible.module_utils import rho_cmd  # pylint: disable=no-name-in-module
+# pylint: disable=no-name-in-module, import-error
+from ansible.module_utils import rho_cmd
 
 if sys.version_info > (3,):
     long = int  # pylint: disable=invalid-name,redefined-builtin
@@ -139,9 +140,9 @@ class RedhatPackagesRhoCmd(rho_cmd.RhoCmd):
                               .splitlines()]
         rh_packages = filter(self.PkgInfo.is_red_hat_pkg,
                              installed_packages)
-        if len(rh_packages) > 0:  # pylint: disable=len-as-condition
-            last_installed = 0
-            last_built = 0
+        if rh_packages:
+            last_installed = None
+            last_built = None
             max_install_time = float("-inf")
             max_build_time = float("-inf")
             for pkg in rh_packages:
@@ -152,17 +153,16 @@ class RedhatPackagesRhoCmd(rho_cmd.RhoCmd):
                     max_build_time = pkg.build_time
                     last_built = pkg
 
-            # pylint: disable=len-as-condition
-            is_red_hat = "Y" if len(rh_packages) > 0 else "N"
+            is_red_hat = "Y" if rh_packages > 0 else "N"
 
             self.data['redhat-packages.is_redhat'] = is_red_hat
             self.data['redhat-packages.num_rh_packages'] = len(rh_packages)
             self.data['redhat-packages.num_installed_packages'] \
                 = len(installed_packages)
             self.data['redhat-packages.last_installed'] \
-                = last_installed.details_install()
+                = last_installed.details_install() if last_installed else 'none'
             self.data['redhat-packages.last_built'] \
-                = last_built.details_built()
+                = last_built.details_built() if last_built else 'none'
         else:
             last_installed = ""
             last_built = ""

--- a/module_utils/redhat_packages_command.py
+++ b/module_utils/redhat_packages_command.py
@@ -157,12 +157,12 @@ class RedhatPackagesRhoCmd(rho_cmd.RhoCmd):
 
             self.data['redhat-packages.is_redhat'] = is_red_hat
             self.data['redhat-packages.num_rh_packages'] = len(rh_packages)
-            self.data['redhat-packages.num_installed_packages'] \
-                = len(installed_packages)
-            self.data['redhat-packages.last_installed'] \
-                = last_installed.details_install() if last_installed else 'none'
-            self.data['redhat-packages.last_built'] \
-                = last_built.details_built() if last_built else 'none'
+            self.data['redhat-packages.num_installed_packages'] = (
+                len(installed_packages))
+            self.data['redhat-packages.last_installed'] = (
+                last_installed.details_install() if last_installed else 'none')
+            self.data['redhat-packages.last_built'] = (
+                last_built.details_built() if last_built else 'none')
         else:
             last_installed = ""
             last_built = ""

--- a/module_utils/redhat_release_command.py
+++ b/module_utils/redhat_release_command.py
@@ -9,12 +9,9 @@
 
 """Check the redhat-release package on the remote machine."""
 
-import gettext
-
-from ansible.module_utils import rho_cmd  # pylint: disable=no-name-in-module
-
-T = gettext.translation('rho', 'locale', fallback=True)
-_ = T.ugettext
+# pylint: disable=no-name-in-module, import-error
+from ansible.module_utils import rho_cmd
+from ansible.module_utils.translation import _
 
 
 # pylint: disable=too-few-public-methods

--- a/module_utils/subman_facts_command.py
+++ b/module_utils/subman_facts_command.py
@@ -9,11 +9,9 @@
 
 """Get information on subscription-manager."""
 
-import gettext
-from ansible.module_utils import rho_cmd  # pylint: disable=no-name-in-module
-
-T = gettext.translation('rho', 'locale', fallback=True)
-_ = T.ugettext
+# pylint: disable=no-name-in-module, import-error
+from ansible.module_utils import rho_cmd
+from ansible.module_utils.translation import _
 
 
 # pylint: disable=too-few-public-methods
@@ -105,8 +103,7 @@ class SubmanFactsRhoCmd(rho_cmd.RhoCmd):
             elif self.cmd_results['subman_has_facts'][0]:
                 fact_files_list = \
                     self.cmd_results['subman_has_facts'][0].strip().split('\n')
-                # pylint: disable=len-as-condition
                 self.data['subman.has_facts_file'] = "Y" \
-                    if len(fact_files_list) > 0 else "N"
+                    if fact_files_list else "N"
         else:
             self.data['subman.has_facts_file'] = 'error'

--- a/module_utils/translation.py
+++ b/module_utils/translation.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2009-2017 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+""" Rho Translation initalization utility """
+
+
+import gettext
+
+T = gettext.translation('rho', 'locale', fallback=True)
+
+if hasattr(T, 'ugettext'):
+    # pylint: disable=no-member
+    _ = T.ugettext
+else:
+    _ = T.gettext
+
+
+# Use this module with 'from translation import _'.

--- a/module_utils/uname_command.py
+++ b/module_utils/uname_command.py
@@ -9,12 +9,9 @@
 
 """Get the system's uname."""
 
-import gettext
-
-from ansible.module_utils import rho_cmd  # pylint: disable=no-name-in-module
-
-T = gettext.translation('rho', 'locale', fallback=True)
-_ = T.ugettext
+# pylint: disable=no-name-in-module, import-error
+from ansible.module_utils import rho_cmd
+from ansible.module_utils.translation import _
 
 
 # pylint: disable=too-few-public-methods

--- a/module_utils/virt_command.py
+++ b/module_utils/virt_command.py
@@ -9,13 +9,9 @@
 
 """Try to determine if the remote machine is a virtualization guest or host."""
 
-import gettext
-
-# pylint: disable=no-name-in-module
+# pylint: disable=no-name-in-module, import-error
 from ansible.module_utils import cpu_command
-
-T = gettext.translation('rho', 'locale', fallback=True)
-_ = T.ugettext
+from ansible.module_utils.translation import _
 
 
 # pylint: disable=too-few-public-methods

--- a/module_utils/virt_what_command.py
+++ b/module_utils/virt_what_command.py
@@ -9,12 +9,9 @@
 
 """Get virt-what information from the remote machine."""
 
-import gettext
-
-from ansible.module_utils import rho_cmd  # pylint: disable=no-name-in-module
-
-T = gettext.translation('rho', 'locale', fallback=True)
-_ = T.ugettext
+# pylint: disable=no-name-in-module, import-error
+from ansible.module_utils import rho_cmd
+from ansible.module_utils.translation import _
 
 
 # pylint: disable=too-few-public-methods
@@ -50,9 +47,8 @@ class VirtWhatRhoCmd(rho_cmd.RhoCmd):
                 self.cmd_names.keys()[0]][0].strip().split('\n')]
             error = int(results[-1:][0])
             virt_what_output = results[:len(results) - 1]
-            # pylint: disable=len-as-condition
             if error == 0:
-                if len(virt_what_output) > 0:
+                if virt_what_output:
                     # quote the results and join on
                     # ',' as virt-what can return multiple values
                     self.data['virt-what.type'] = '"%s"' % "," \

--- a/rho/authaddcommand.py
+++ b/rho/authaddcommand.py
@@ -102,7 +102,7 @@ class AuthAddCommand(CliCommand):
 
     def _do_command(self):
         vault = get_vault(self.options.vaultfile)
-        cred = {}
+        cred = OrderedDict()
         ssh_file = 'empty'
         pass_to_store = ''
         auth_name = self.options.name

--- a/rho/profileaddcommand.py
+++ b/rho/profileaddcommand.py
@@ -122,8 +122,7 @@ class ProfileAddCommand(CliCommand):
 
         range_list = hosts_list
 
-        # pylint: disable=len-as-condition
-        if len(hosts_list) > 0 and os.path.isfile(hosts_list[0]):
+        if hosts_list and os.path.isfile(hosts_list[0]):
             range_list = _read_in_file(hosts_list[0])
 
         _check_range_validity(range_list)

--- a/rho/profileeditcommand.py
+++ b/rho/profileeditcommand.py
@@ -97,8 +97,7 @@ class ProfileEditCommand(CliCommand):
         if self.options.hosts:
             hosts_list = self.options.hosts
             range_list = hosts_list
-            # pylint: disable=len-as-condition
-            if len(hosts_list) > 0 and os.path.isfile(hosts_list[0]):
+            if hosts_list > 0 and os.path.isfile(hosts_list[0]):
                 range_list = _read_in_file(hosts_list[0])
 
             # makes sure the hosts passed in are in a format Ansible

--- a/rho/profileeditcommand.py
+++ b/rho/profileeditcommand.py
@@ -97,7 +97,7 @@ class ProfileEditCommand(CliCommand):
         if self.options.hosts:
             hosts_list = self.options.hosts
             range_list = hosts_list
-            if hosts_list > 0 and os.path.isfile(hosts_list[0]):
+            if os.path.isfile(hosts_list[0]):
                 range_list = _read_in_file(hosts_list[0])
 
             # makes sure the hosts passed in are in a format Ansible

--- a/rho/scancommand.py
+++ b/rho/scancommand.py
@@ -114,10 +114,7 @@ def _create_ping_inventory(vault, vault_pass, profile_ranges, profile_port,
                 success_map[host_ip].append(tup_auth_item)
                 success_port_map[host_ip] = profile_port
 
-    success_auths = list(success_auths)
-    success_hosts = list(success_hosts)
-
-    return success_auths, success_hosts, best_map, success_map, \
+    return list(success_auths), list(success_hosts), best_map, success_map, \
         success_port_map
 
 
@@ -339,7 +336,7 @@ class ScanCommand(CliCommand):
                                                           profile_auth_list,
                                                           forks)
 
-            if not len(success_auths):  # pylint: disable=len-as-condition
+            if not success_auths:
                 print(_('All auths are invalid for this profile'))
                 sys.exit(1)
 

--- a/rho/translation.py
+++ b/rho/translation.py
@@ -19,6 +19,7 @@ T = gettext.translation('rho', 'locale', fallback=True)
 def get_translation():
     """Obtains the locale based translation setup for rho"""
     if hasattr(T, 'ugettext'):
+        # pylint: disable=no-member
         _ = T.ugettext
     else:
         _ = T.gettext

--- a/test/test_clicommand.py
+++ b/test/test_clicommand.py
@@ -14,12 +14,12 @@
 """ Unit tests for CLI """
 
 import contextlib
-import io
 import unittest
 import sys
 import os
 import tempfile
 import mock
+import six
 from rho import vault
 from rho import utilities
 from rho.authaddcommand import AuthAddCommand
@@ -245,7 +245,7 @@ class CliCommandsTests(unittest.TestCase):
 
         sys.argv = ['/bin/rho', "auth", "list", "--vault",
                     TMP_VAULT_PASS]
-        auth_list_out = io.StringIO()
+        auth_list_out = six.StringIO()
         with redirect_credentials([
             {'id': '1', 'name': 'name', 'username': 'username',
              'password': 'password', 'ssh_key_file': 'file'}]):
@@ -281,7 +281,7 @@ class CliCommandsTests(unittest.TestCase):
                     "--vault", TMP_VAULT_PASS]
         creds = [{'id': '1', 'name': 'auth_1', 'username': 'user_1',
                   'password': 'password', 'ssh_key_file': 'file_1'}]
-        auth_show_out = io.StringIO()
+        auth_show_out = six.StringIO()
         with redirect_credentials(creds):
             with redirect_stdout(auth_show_out):
                 AuthShowCommand().main()
@@ -423,7 +423,7 @@ class CliCommandsTests(unittest.TestCase):
 
         sys.argv = ['/bin/rho', "profile", "list",
                     "--vault", TMP_VAULT_PASS]
-        profiles_list_out = io.StringIO()
+        profiles_list_out = six.StringIO()
         with redirect_credentials([]):
             with redirect_profiles([{
                 'name': 'p1',
@@ -459,7 +459,7 @@ class CliCommandsTests(unittest.TestCase):
 
         sys.argv = ['/bin/rho', "profile", "show", "--name",
                     "p1", "--vault", TMP_VAULT_PASS]
-        profile_show_out = io.StringIO()
+        profile_show_out = six.StringIO()
         with redirect_profiles([{
             'name': 'p1',
             'hosts': ['1.2.3.4'],


### PR DESCRIPTION
This will let us catch Python 3 errors before the code gets to
Travis. This commit adds Python 3 linting, and also updates Rho to
pass Python 3 linting cleanly.