### PR TITLE
Remove non-working code

### DIFF
--- a/roles/brms/tasks/main.yml
+++ b/roles/brms/tasks/main.yml
@@ -15,8 +15,3 @@
       raw: OIFS="$IFS"; IFS=$'\n'; for war in $(find / -name kie*.war 2> /dev/null); do if [[ -d  "$war" ]]; then cat "$war"/META-INF/MANIFEST.MF 2> /dev/null | grep Implementation-Version | sed "s/Implementation-Version://g" | sed "s/ //g" | sed 's/\r$//' | sort -u; else fgrep -irsal kie-api "$war" | egrep -o "[0-9]\.[0-9]\.[0-9].*-" | sed "s/-$//g" | sed 's/\r$//' | sort -u; fi; done; IFS="$OIFS"
       register: kie-war-ver
       ignore_errors: yes
-
-    #- name: Gather brms.business-central-war-ver
-    #  raw: OIFS="$IFS"; IFS=$'\n'; for war in $(find / -name kie*.war 2> /dev/null); do if [[ -d  "$war" ]]; then cat "$war"/META-INF/MANIFEST.MF | grep Implementation-Version | sed "s/Implementation-Version://g" | sort -u; else fgrep -irsal kie-api "$war" | egrep -o "[0-9]\.[0-9]\.[0-9].*-" | sed "s/-$//g"; fi | sort -u; done; IFS="$OIFS"
-    #  register: business-central-war-ver
-    #  ignore_errors: yes


### PR DESCRIPTION
Remove some commented-out, non-working code from the BRMS role. Closes #123 .