### PR TITLE
Check the exit code and signal status of ansible playbook process to …

### DIFF
--- a/rho/scancommand.py
+++ b/rho/scancommand.py
@@ -208,7 +208,7 @@ def run_ansible_with_vault(cmd_string, vault_pass, ssh_key_passphrase=None,
             child.sendline(ssh_key_passphrase)
             child.logfile = logfile
             child.expect(pexpect.EOF)
-        return child.before
+        return child
     except pexpect.EOF:
         print(str(result))
         print('pexpect unexpected EOF')
@@ -396,9 +396,13 @@ class ScanCommand(CliCommand):
         # process finally runs ansible on the
         # playbook and inventories thus created.
         print('Running:', cmd_string)
-        run_ansible_with_vault(cmd_string, vault_pass)
-
-        print(_("Scanning has completed. The mapping has been"
-                " stored in file 'data/" + self.options.profile +
-                "_host_auth_mapping'. The facts have been stored in '" +
-                report_path + "'"))
+        process = run_ansible_with_vault(cmd_string, vault_pass)
+        process.close()
+        if process.exitstatus == 0 and process.signalstatus is None:
+            print(_("Scanning has completed. The mapping has been"
+                    " stored in file 'data/" + self.options.profile +
+                    "_host_auth_mapping'. The facts have been stored in '" +
+                    report_path + "'"))
+        else:
+            print(_("An error has occurred during the scan. Please review" +
+                    " the output to resolve the given issue."))


### PR DESCRIPTION
…determine final output or error message.

I forced an error by creating an issue in one of the roles. Output on failure shown below:
```
TASK [cpu : add cpu.blah to dictionary] ****************************************
fatal: [10.10.181.9]: FAILED! => {"failed": true, "msg": "the field 'args' has an invalid value, which appears to include a variable that is undefined. The error was: 'cpu_blah' is undefined\n\nThe error appears to have been in '/Users/christopherhambridge/Code/rho/roles/cpu/tasks/main.yml': line 20, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: add cpu.blah to dictionary\n  ^ here\n"}
	to retry, use: --limit @/Users/christopherhambridge/Code/rho/rho_playbook.retry

PLAY RECAP *********************************************************************
10.10.181.9                : ok=6    changed=1    unreachable=0    failed=1   

An error has occurred during the scan. Please review the output to resolve the given issue.
```

Not having this PR close issue #137 until I understand the state of the dependency problem that was also reported.