### PR TITLE
update JBoss processing flow to capture values in csv output. Closes …

### DIFF
--- a/test/test_spit_results.py
+++ b/test/test_spit_results.py
@@ -44,7 +44,10 @@ class TestSpitResults(unittest.TestCase):
                          {'fact1': 'value1',
                           'fact2': 'value2',
                           'res': {'fact3': 'value3'},
-                          'connection.uuid': '1'}},
+                          'connection:': {'connection.uuid': '1'},
+                          'jboss.jar-ver':
+                          {'stdout_lines':
+                           ['1.5.4.Final-redhat-1**2017-08-03']}}},
             "fact_names": ['fact1', 'connection.uuid',
                            'systemid.username',
                            'redhat-packages.last_built']

--- a/test/test_spit_results.py
+++ b/test/test_spit_results.py
@@ -44,13 +44,14 @@ class TestSpitResults(unittest.TestCase):
                          {'fact1': 'value1',
                           'fact2': 'value2',
                           'res': {'fact3': 'value3'},
-                          'connection:': {'connection.uuid': '1'},
+                          'connection': {'connection.uuid': '1'},
                           'jboss.jar-ver':
                           {'stdout_lines':
                            ['1.5.4.Final-redhat-1**2017-08-03']}}},
             "fact_names": ['fact1', 'connection.uuid',
                            'systemid.username',
-                           'redhat-packages.last_built']
+                           'redhat-packages.last_built',
+                           'jboss.deploy-dates', 'jboss.installed-versions']
         }
         mod_obj.params = args
         spit_results.main()


### PR DESCRIPTION
…#144.


Below is the captured output from a run with these updates:
```
connection.host,connection.port,connection.uuid,cpu.bogomips,cpu.count,cpu.cpu_family,cpu.model_name,cpu.model_ver,cpu.socket_count,cpu.vendor_id,date.anaconda_log,date.date,date.filesystem_create,date.machine_id,date.yum_history,dmi.bios-vendor,dmi.bios-version,dmi.processor-family,dmi.system-manufacturer,etc-issue.etc-issue,etc_release.name,etc_release.release,etc_release.version,instnum.instnum,jboss.brms.drools-core-ver,jboss.brms.kie-api-ver,jboss.brms.kie-war-ver,jboss.deploy-dates,jboss.fuse.activemq-ver,jboss.fuse.camel-ver,jboss.fuse.cxf-ver,jboss.installed-versions,jboss.running-versions,redhat-packages.is_redhat,redhat-packages.last_built,redhat-packages.last_installed,redhat-packages.num_installed_packages,redhat-packages.num_rh_packages,redhat-release.name,redhat-release.release,redhat-release.version,subman.cpu.core(s)_per_socket,subman.cpu.cpu(s),subman.cpu.cpu_socket(s),subman.has_facts_file,subman.virt.host_type,subman.virt.is_guest,subman.virt.uuid,systemid.system_id,systemid.username,uname.all,uname.hardware_platform,uname.hostname,uname.kernel,uname.os,uname.processor,virt-what.type,virt.num_guests,virt.num_running_guests,virt.type,virt.virt
10.10.181.9,22,f9fbdca6-c838-576b-9eeb-bad9debae376,5400.00,1,6,Intel(R) Xeon(R) CPU E5-2697 v2 @ 2.70GHz,62,1,GenuineIntel,2017-07-25,Thu Aug  3 14:01:20 EDT 2017,tune2fs: Bad magic number in super-block while trying to open /dev/mapper/rhel_dhcp182--50-root,2017-07-25,2017-08-03,Phoenix Technologies LTD,6.00,Unknown,"VMware, Inc.",\SKernel \r on an \m,Red Hat Enterprise Linux Server ,Red Hat Enterprise Linux Server release 7.4 (Maipo), 7.4 (Maipo),,,,,2017-08-03,,,,EAP-7.0,/opt/rh/eap7,Y,java-1.8.0-openjdk-headless-1.8.0.141-2.b16.el7_4 Built: Fri 14 Jul 2017 12:27:41 PM EDT,eap7-artemis-native-wildfly-1.1.0-12.redhat_4.ep7.el7 Installed: Thu 03 Aug 2017 09:04:40 AM EDT,666,664,redhat-release-server,18.el7,7.4,1,1,1,N,vmware,True,69BB1E42-0D99-CFB7-1371-40A1B3785DB9,,,Linux dhcp181-9.gsslab.rdu2.redhat.com 3.10.0-693.el7.x86_64 #1 SMP Thu Jul 6 19:56:57 EDT 2017 x86_64 x86_64 x86_64 GNU/Linux,x86_64,dhcp181-9.gsslab.rdu2.redhat.com,3.10.0-693.el7.x86_64,Linux,x86_64,vmware,bash: virsh: command not found,bash: virsh: command not found,vmware,virt-guest
```