### PR TITLE
Install JBoss on test VM

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,7 @@
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "centos/7"
+  config.vm.box = "rhel-server-7-1"
 
   # Define a test box to be scanned during tests
   config.vm.define "test_1" do |test_1|

--- a/doc/functional_test.rst
+++ b/doc/functional_test.rst
@@ -60,6 +60,19 @@ directory. Run the following command to provision the systems::
 
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Note: testing on RHEL
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The Vagrantfile assumes the existance of a Vagrant box called
+`rhel-server-7-1`. You can make a RHEL box by following one of the
+many tutorials, such as
+https://developers.redhat.com/blog/2016/06/06/using-vagrant-to-get-started-with-rhel/
+.
+
+If you don't want to test with RHEL, you can replace that box name
+with a different one, such as `centos/7`.
+
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Executing rho on Test Bed
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 You should have three virtual systems running with the following IP Address:

--- a/vagrant/roles/jboss-standalone/tasks/main.yml
+++ b/vagrant/roles/jboss-standalone/tasks/main.yml
@@ -1,0 +1,26 @@
+---
+# This role is based on the jboss-standalone role from the Ansible
+# examples, but it includes only the parts we need to test Rho.
+
+- name: Install unzip
+  yum: 
+    name: unzip
+    state: present
+  become: yes
+  become_user: root
+
+- name: Download JBoss from jboss.org
+  get_url: 
+    url: http://download.jboss.org/jbossas/7.1/jboss-as-7.1.1.Final/jboss-as-7.1.1.Final.zip 
+    dest: /opt/jboss-as-7.1.1.Final.zip
+  become: yes
+  become_user: root
+
+- name: Extract archive
+  unarchive: 
+    dest: /usr/share 
+    src: /opt/jboss-as-7.1.1.Final.zip 
+    creates: /usr/share/jboss-as 
+    copy: no 
+  become: yes
+  become_user: root

--- a/vagrant/setup-test-vms.yml
+++ b/vagrant/setup-test-vms.yml
@@ -3,3 +3,7 @@
     - role: user-ssh
       become: yes
       become_user: root
+
+- hosts: test_2
+  roles:
+    - jboss-standalone


### PR DESCRIPTION
This lets us verify that Rho is actually detecting JBoss.

Only install JBoss on one of the test machines so we can also verify that Rho doesn't detect JBoss where it doesn't belong.

The JBoss setup is based on an Ansible example, but I removed the part that actually starts JBoss and just had it download and untar the package. It would be better to actually have JBoss running, but the playbook hit an error in the `template` module which Sloane from the Ansible team is helping me debug. Once that's done I can keep trying.

@chambridge this is part of fixing #71 . What else did you want to be part of that issue?