### PR TITLE
Simplify rho.translation module

### DIFF
--- a/rho/authaddcommand.py
+++ b/rho/authaddcommand.py
@@ -23,9 +23,7 @@ from collections import OrderedDict
 from rho import utilities
 from rho.clicommand import CliCommand
 from rho.vault import get_vault
-from rho.translation import get_translation
-
-_ = get_translation()
+from rho.translation import _
 
 
 def auth_exists(cred_list, auth_name):

--- a/rho/authclearcommand.py
+++ b/rho/authclearcommand.py
@@ -20,9 +20,7 @@ import sys
 from rho import utilities
 from rho.clicommand import CliCommand
 from rho.vault import get_vault
-from rho.translation import get_translation
-
-_ = get_translation()
+from rho.translation import _
 
 
 class AuthClearCommand(CliCommand):

--- a/rho/autheditcommand.py
+++ b/rho/autheditcommand.py
@@ -21,9 +21,7 @@ from getpass import getpass
 from rho import utilities
 from rho.clicommand import CliCommand
 from rho.vault import get_vault
-from rho.translation import get_translation
-
-_ = get_translation()
+from rho.translation import _
 
 
 def optional_arg(arg_default):

--- a/rho/authlistcommand.py
+++ b/rho/authlistcommand.py
@@ -21,9 +21,7 @@ import json
 from rho import utilities
 from rho.clicommand import CliCommand
 from rho.vault import get_vault
-from rho.translation import get_translation
-
-_ = get_translation()
+from rho.translation import _
 
 
 class AuthListCommand(CliCommand):

--- a/rho/authshowcommand.py
+++ b/rho/authshowcommand.py
@@ -20,9 +20,7 @@ import json
 from rho import utilities
 from rho.clicommand import CliCommand
 from rho.vault import get_vault
-from rho.translation import get_translation
-
-_ = get_translation()
+from rho.translation import _
 
 
 class AuthShowCommand(CliCommand):

--- a/rho/cli.py
+++ b/rho/cli.py
@@ -31,9 +31,6 @@ from rho.profileeditcommand import ProfileEditCommand  # noqa
 from rho.profilelistcommand import ProfileListCommand  # noqa
 from rho.profileshowcommand import ProfileShowCommand  # noqa
 from rho.scancommand import ScanCommand  # noqa
-from rho.translation import get_translation
-
-_ = get_translation()
 
 
 class CLI(object):

--- a/rho/clicommand.py
+++ b/rho/clicommand.py
@@ -15,9 +15,7 @@
 from __future__ import print_function
 import sys
 from optparse import OptionParser  # pylint: disable=deprecated-module
-from rho.translation import get_translation
-
-_ = get_translation()
+from rho.translation import _
 
 
 class CliCommand(object):

--- a/rho/profileaddcommand.py
+++ b/rho/profileaddcommand.py
@@ -22,9 +22,7 @@ from rho import utilities
 from rho.clicommand import CliCommand
 from rho.vault import get_vault
 from rho.utilities import multi_arg, _check_range_validity, _read_in_file
-from rho.translation import get_translation
-
-_ = get_translation()
+from rho.translation import _
 
 
 def profile_exists(profile_list, profile_name):

--- a/rho/profileclearcommand.py
+++ b/rho/profileclearcommand.py
@@ -21,9 +21,7 @@ import glob
 from rho import utilities
 from rho.clicommand import CliCommand
 from rho.vault import get_vault
-from rho.translation import get_translation
-
-_ = get_translation()
+from rho.translation import _
 
 
 class ProfileClearCommand(CliCommand):

--- a/rho/profileeditcommand.py
+++ b/rho/profileeditcommand.py
@@ -21,9 +21,7 @@ from rho import utilities
 from rho.clicommand import CliCommand
 from rho.vault import get_vault
 from rho.utilities import multi_arg, _check_range_validity, _read_in_file
-from rho.translation import get_translation
-
-_ = get_translation()
+from rho.translation import _
 
 
 class ProfileEditCommand(CliCommand):

--- a/rho/profilelistcommand.py
+++ b/rho/profilelistcommand.py
@@ -21,9 +21,7 @@ import json
 from rho import utilities
 from rho.clicommand import CliCommand
 from rho.vault import get_vault
-from rho.translation import get_translation
-
-_ = get_translation()
+from rho.translation import _
 
 
 class ProfileListCommand(CliCommand):

--- a/rho/profileshowcommand.py
+++ b/rho/profileshowcommand.py
@@ -21,9 +21,7 @@ import json
 from rho import utilities
 from rho.clicommand import CliCommand
 from rho.vault import get_vault
-from rho.translation import get_translation
-
-_ = get_translation()
+from rho.translation import _
 
 
 class ProfileShowCommand(CliCommand):

--- a/rho/scancommand.py
+++ b/rho/scancommand.py
@@ -24,9 +24,7 @@ from rho import utilities
 from rho.clicommand import CliCommand
 from rho.vault import get_vault_and_password
 from rho.utilities import multi_arg, _read_in_file, str_to_ascii
-from rho.translation import get_translation
-
-_ = get_translation()
+from rho.translation import _
 
 
 # Read ssh key from file
@@ -101,11 +99,12 @@ def _create_ping_inventory(vault, vault_pass, profile_ranges, profile_port,
         with open('data/ping_log', 'r') as ping_log:
             out = ping_log.readlines()
 
-        for line, _ in enumerate(out):
-            if 'pong' in out[line]:
+        # pylint: disable=unused-variable
+        for linenum, line in enumerate(out):
+            if 'pong' in out[linenum]:
                 tup_auth_item = tuple(auth_item)
                 success_auths.add(tup_auth_item)
-                host_line = out[line - 2].replace('\x1b[0;32m', '')
+                host_line = out[linenum - 2].replace('\x1b[0;32m', '')
                 host_ip = host_line.split('|')[0].strip()
                 success_hosts.add(host_ip)
                 if host_ip not in mapped_hosts:

--- a/rho/translation.py
+++ b/rho/translation.py
@@ -15,12 +15,8 @@ import gettext
 
 T = gettext.translation('rho', 'locale', fallback=True)
 
-
-def get_translation():
-    """Obtains the locale based translation setup for rho"""
-    if hasattr(T, 'ugettext'):
-        # pylint: disable=no-member
-        _ = T.ugettext
-    else:
-        _ = T.gettext
-    return _
+if hasattr(T, 'ugettext'):
+    # pylint: disable=no-member
+    _ = T.ugettext
+else:
+    _ = T.gettext

--- a/rho/utilities.py
+++ b/rho/utilities.py
@@ -14,7 +14,7 @@ from __future__ import print_function
 import os
 import sys
 import re
-from rho.translation import get_translation
+from rho.translation import _
 
 CREDENTIALS_PATH = 'data/credentials'
 PROFILES_PATH = 'data/profiles'
@@ -110,9 +110,6 @@ def ensure_config_dir_exists():
 
     if not os.path.exists('data'):
         os.makedirs('data')
-
-
-_ = get_translation()
 
 
 # pylint: disable=unused-argument


### PR DESCRIPTION
Instead of rho.translation exporting a function which then returns the
gettext lookup function, just have the module export the right
function.

Also do some minor cleanups in scancommand.py to fix lint errors.

Closes #150 .