### PR TITLE
Add verbosity flags

### DIFF
--- a/doc/command_syntax_usage.rst
+++ b/doc/command_syntax_usage.rst
@@ -89,8 +89,8 @@ default, for debugging. This location can be changed with the
 Common Flags
 ^^^^^^^^^^^^
 
-All Rho commands accept the `-v` flag, which increases the verbosity
-of Rho's output. It comes in four varieties: `-v`, `-vv`, `-vvv`, and
+All rho commands accept the `-v` flag, which increases the verbosity
+of rho's output. It comes in four varieties: `-v`, `-vv`, `-vvv`, and
 `-vvvv`, with more `v`'s indicating more verbose output. The verbose
 output can be useful in debugging.
 

--- a/doc/command_syntax_usage.rst
+++ b/doc/command_syntax_usage.rst
@@ -68,6 +68,19 @@ to pass in auths as per the priority they deem fit for a profile. If a non root
 auth is better tried first and then the root auth then the user has to pass in the
 auths in the order as ``--auth <nonroot_1> <nonroot_2> <root_1> <root_2>`` etc.
 
+The output of the Ansible process is saved to `data/scan_log` by
+default, for debugging. This location can be changed with the
+`--logfile` flag.
+
+^^^^^^^^^^^^
+Common Flags
+^^^^^^^^^^^^
+
+All Rho commands accept the `-v` flag, which increases the verbosity
+of Rho's output. It comes in four varieties: `-v`, `-vv`, `-vvv`, and
+`-vvvv`, with more `v`'s indicating more verbose output. The verbose
+output can be useful in debugging.
+
 ^^^^^^^
 Output
 ^^^^^^^

--- a/rho/clicommand.py
+++ b/rho/clicommand.py
@@ -35,7 +35,9 @@ class CliCommand(object):
         self.options = None
         self.verbosity = 0
 
-        self.parser.add_option("-v", dest="verbosity", action="count")
+        self.parser.add_option(
+            "-v", dest="verbosity", action="count",
+            help=_("Verbose mode. Use up to -vvvv for more verbosity."))
 
     def _validate_options(self):
         """

--- a/rho/clicommand.py
+++ b/rho/clicommand.py
@@ -13,6 +13,7 @@
 """ Base CLI Command Class """
 
 from __future__ import print_function
+import logging
 import sys
 from optparse import OptionParser  # pylint: disable=deprecated-module
 from rho.translation import _
@@ -32,6 +33,10 @@ class CliCommand(object):
         self.passphrase = None
         self.args = None
         self.options = None
+        self.verbosity = 0
+
+        self.parser.add_option("-v", dest="verbosity", action="count")
+
 
     def _validate_options(self):
         """
@@ -60,6 +65,21 @@ class CliCommand(object):
         self.args = self.args[1:]
 
         self._validate_options()
+
+        # Verbosity propagates in two ways to the individual commands:
+        # first, as self.verbosity, and second, through the default
+        # log level for the logging module. This means that other
+        # modules can just use Python logging and it will work with
+        # the verbosity by default.
+        self.verbosity = self.options.verbosity
+        if self.verbosity == 0:
+            log_level = logging.WARNING
+        elif self.verbosity == 1:
+            log_level = logging.INFO
+        else:
+            log_level = logging.DEBUG
+
+        logging.basicConfig(level=log_level)
 
         if len(sys.argv) < 2:
 

--- a/rho/clicommand.py
+++ b/rho/clicommand.py
@@ -37,7 +37,6 @@ class CliCommand(object):
 
         self.parser.add_option("-v", dest="verbosity", action="count")
 
-
     def _validate_options(self):
         """
         Sub-commands can override to do any argument validation they

--- a/rho/scancommand.py
+++ b/rho/scancommand.py
@@ -41,7 +41,7 @@ def _read_key_file(filename):
 # successful auths and the hosts they worked on
 # pylint: disable=too-many-statements, too-many-arguments
 def _create_ping_inventory(vault, vault_pass, profile_ranges, profile_port,
-                           profile_auth_list, forks):
+                           profile_auth_list, forks, ansible_verbosity):
     # pylint: disable=too-many-locals
     success_auths = set()
     success_hosts = set()
@@ -96,7 +96,8 @@ def _create_ping_inventory(vault, vault_pass, profile_ranges, profile_port,
         run_ansible_with_vault(cmd_string, vault_pass,
                                log_path='data/ping_log',
                                env=my_env,
-                               log_to_stdout=False)
+                               log_to_stdout=True,
+                               ansible_verbosity=ansible_verbosity)
 
         with open('data/ping_log', 'r') as ping_log:
             out = ping_log.readlines()
@@ -193,7 +194,8 @@ def _create_main_inventory(vault, success_hosts, success_port_map, best_map,
 
 
 def run_ansible_with_vault(cmd_string, vault_pass, ssh_key_passphrase=None,
-                           env=None, log_path=None, log_to_stdout=True):
+                           env=None, log_path=None, log_to_stdout=True,
+                           ansible_verbosity=0):
     """ Runs ansible command allowing for password to be provided after
     process triggered.
 
@@ -207,6 +209,7 @@ def run_ansible_with_vault(cmd_string, vault_pass, ssh_key_passphrase=None,
         'data/ansible_log'.
     :param log_to_stdout: if True, write Ansible's log to stdout. Defaults to
         True.
+    :param ansible_verbosity: the number of v's of Ansible verbosity.
     :returns: the popen.spawn object for the process.
     """
 
@@ -217,6 +220,9 @@ def run_ansible_with_vault(cmd_string, vault_pass, ssh_key_passphrase=None,
 
     if not log_path:
         log_path = 'data/ansible_log'
+
+    if ansible_verbosity:
+        cmd_string = cmd_string + ' -' + 'v' * ansible_verbosity
 
     result = None
     try:
@@ -393,7 +399,8 @@ class ScanCommand(CliCommand):
                                                           profile_ranges,
                                                           profile_port,
                                                           profile_auth_list,
-                                                          forks)
+                                                          forks,
+                                                          self.verbosity)
 
             if not success_auths:
                 print(_('All auths are invalid for this profile'))
@@ -426,7 +433,7 @@ class ScanCommand(CliCommand):
                         'report_path': report_path}
 
         cmd_string = ('ansible-playbook rho_playbook.yml '
-                      '-i data/{profile}_hosts.yml -v -f {forks} '
+                      '-i data/{profile}_hosts.yml -f {forks} '
                       '--ask-vault-pass '
                       '--extra-vars \'{vars}\'').format(
                           profile=profile,
@@ -442,7 +449,8 @@ class ScanCommand(CliCommand):
         print('Running:', cmd_string)
         process = run_ansible_with_vault(cmd_string, vault_pass,
                                          log_path=log_path,
-                                         log_to_stdout=True)
+                                         log_to_stdout=True,
+                                         ansible_verbosity=self.verbosity)
         if process.exitstatus == 0 and process.signalstatus is None:
             print(_("Scanning has completed. The mapping has been"
                     " stored in file 'data/" + self.options.profile +

--- a/test/test_clicommand.py
+++ b/test/test_clicommand.py
@@ -14,6 +14,7 @@
 """ Unit tests for CLI """
 
 import contextlib
+import logging
 import unittest
 import sys
 import os
@@ -27,6 +28,7 @@ from rho.authlistcommand import AuthListCommand
 from rho.authclearcommand import AuthClearCommand
 from rho.autheditcommand import AuthEditCommand
 from rho.authshowcommand import AuthShowCommand
+from rho.clicommand import CliCommand
 from rho.factlistcommand import FactListCommand
 from rho.profileaddcommand import ProfileAddCommand
 from rho.profileclearcommand import ProfileClearCommand
@@ -639,3 +641,16 @@ class CliCommandsTests(unittest.TestCase):
                         "bad.fact1", "bad.fact2", "ansible_forks",
                         "100", "--vault", TMP_VAULT_PASS]
             ScanCommand().main()
+
+    def test_verbosity(self):
+        """Test that -vv sets verbosity and log level correctly."""
+
+        command = CliCommand()
+        sys.argv = ['/bin/rho', '-vv']
+
+        # CliCommand.main() will set up the command's environment but
+        # not actually do anything.
+        command.main()
+
+        self.assertEqual(command.verbosity, 2)
+        self.assertEqual(logging.getLogger().getEffectiveLevel(), logging.DEBUG)

--- a/test/test_clicommand.py
+++ b/test/test_clicommand.py
@@ -653,4 +653,5 @@ class CliCommandsTests(unittest.TestCase):
         command.main()
 
         self.assertEqual(command.verbosity, 2)
-        self.assertEqual(logging.getLogger().getEffectiveLevel(), logging.DEBUG)
+        self.assertEqual(logging.getLogger().getEffectiveLevel(),
+                         logging.DEBUG)


### PR DESCRIPTION
Add a verbosity flag that works the same way that Ansible's does (-v,
-vv, -vvv, and -vvvv for different levels of verbosity). Propagate it
to Ansible in 'rho scan'.

Also use the verbosity to set the Python logging level, so that Rho
itself can use the native Python logging.

Closes #127.