### PR TITLE
exit with return code 1 if trying to edit when data/credentials file …

### DIFF
--- a/rho/autheditcommand.py
+++ b/rho/autheditcommand.py
@@ -103,6 +103,7 @@ class AuthEditCommand(CliCommand):
 
         if not os.path.isfile(utilities.CREDENTIALS_PATH):
             print(_("No auth credentials found"))
+            sys.exit(1)
         else:
             cred_list = vault.load_as_json(utilities.CREDENTIALS_PATH)
 


### PR DESCRIPTION
…doesn't exist.