### PR TITLE
Add test setup for become-with-password

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,8 +3,8 @@ VAGRANTFILE_API_VERSION = "2"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "rhel-server-7-1"
 
-  # Define a test box to be scanned during tests
-  config.vm.define "test_1" do |test_1|
+    # Define a test box to be scanned during tests
+    config.vm.define "test_1" do |test_1|
         test_1.vm.network "private_network", ip: "192.168.50.10"
 
         test_1.vm.provision "ansible" do |ansible|
@@ -14,19 +14,28 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     # Define a test box to be scanned during tests
     config.vm.define "test_2" do |test_2|
-          test_2.vm.network "private_network", ip: "192.168.50.11"
+        test_2.vm.network "private_network", ip: "192.168.50.11"
 
-          test_2.vm.provision "ansible" do |ansible|
-              ansible.playbook = "vagrant/setup-test-vms.yml"
-          end
-      end
-
-      # Define a test box to be scanned during tests
-      config.vm.define "test_3" do |test_3|
-            test_3.vm.network "private_network", ip: "192.168.50.12"
-
-            test_3.vm.provision "ansible" do |ansible|
-                ansible.playbook = "vagrant/setup-test-vms.yml"
-            end
+        test_2.vm.provision "ansible" do |ansible|
+            ansible.playbook = "vagrant/setup-test-vms.yml"
         end
+    end
+
+    # Define a test box to be scanned during tests
+    config.vm.define "test_3" do |test_3|
+        test_3.vm.network "private_network", ip: "192.168.50.12"
+
+        test_3.vm.provision "ansible" do |ansible|
+            ansible.playbook = "vagrant/setup-test-vms.yml"
+        end
+    end
+
+    # A test box that requires a password for sudo
+    config.vm.define "askpass" do |test_3|
+        test_3.vm.network "private_network", ip: "192.168.50.13"
+
+        test_3.vm.provision "ansible" do |ansible|
+            ansible.playbook = "vagrant/setup-test-vms.yml"
+        end
+    end
 end

--- a/vagrant/setup-test-vms.yml
+++ b/vagrant/setup-test-vms.yml
@@ -7,3 +7,13 @@
 - hosts: test_2
   roles:
     - jboss-standalone
+
+- hosts: askpass
+  tasks:
+    - user:
+        name: askpass
+        state: present
+        groups: wheel
+        # Crypted version of "password"
+        password: $6$ZBtzwTi5YgUbr1cT$jVTtaH6lVVTndZJLHqcWtZoxPS0Siz/ms8bOKA/F/r1Np0zeptDERYIfbmRN0dLbu9Z7S./bIGzGR9nUXl59W/
+  become: yes


### PR DESCRIPTION
Add a new VM to the Vagrant test setup. It has a user that can sudo
with a password.

Extra formatting changes in Vagrantfile are due to the fact that I got my editor to automatically format it. After this PR, Vagrantfile formatting will be consistent.