### PR TITLE
Make scan work with -vvv

### DIFF
--- a/rho/scancommand.py
+++ b/rho/scancommand.py
@@ -39,7 +39,7 @@ def _read_key_file(filename):
 
 # Creates the inventory for pinging all hosts and records
 # successful auths and the hosts they worked on
-# pylint: disable=too-many-statements, too-many-arguments
+# pylint: disable=too-many-statements, too-many-arguments, unused-argument
 def _create_ping_inventory(vault, vault_pass, profile_ranges, profile_port,
                            profile_auth_list, forks, ansible_verbosity):
     # pylint: disable=too-many-locals

--- a/rho/scancommand.py
+++ b/rho/scancommand.py
@@ -93,11 +93,15 @@ def _create_ping_inventory(vault, vault_pass, profile_ranges, profile_port,
 
         my_env = os.environ.copy()
         my_env["ANSIBLE_HOST_KEY_CHECKING"] = "False"
+        # Don't pass ansible_verbosity here as adding too much
+        # verbosity can break our parsing of Ansible's output. This is
+        # a temporary fix - a better solution would be less-fragile
+        # output parsing.
         run_ansible_with_vault(cmd_string, vault_pass,
                                log_path='data/ping_log',
                                env=my_env,
                                log_to_stdout=True,
-                               ansible_verbosity=ansible_verbosity)
+                               ansible_verbosity=0)
 
         with open('data/ping_log', 'r') as ping_log:
             out = ping_log.readlines()


### PR DESCRIPTION
Temporary workaround to make scan command work with increased Ansible
verbosity.