### PR TITLE
Issues/122 part 2

### DIFF
--- a/rho/scancommand.py
+++ b/rho/scancommand.py
@@ -14,7 +14,6 @@
 
 from __future__ import print_function
 import logging
-import yaml
 import os
 import sys
 import re
@@ -23,6 +22,7 @@ import json
 import subprocess
 from collections import defaultdict
 import pexpect
+import yaml
 from rho import utilities
 from rho.clicommand import CliCommand
 from rho.vault import get_vault_and_password
@@ -65,7 +65,7 @@ def auth_as_ansible_host_vars(auth):
     return ansible_vars
 
 
-def format_auth_for_host_auth_mapping(auth):
+def redacted_auth_string(auth):
     """Format an auth for the host auth mapping file.
 
     :param auth: the auth. A dictionary with fields 'id', 'name',
@@ -124,9 +124,6 @@ def _create_ping_inventory(vault, vault_pass, profile_ranges, profile_port,
             hosts_dict[hostname] = None
 
     for cred_item in profile_auth_list:
-        cred_pass = cred_item.get('password')
-        cred_sshkey = cred_item.get('ssh_key_file')
-
         vars_dict = auth_as_ansible_host_vars(cred_item)
 
         yml_dict = {'all': {'hosts': hosts_dict, 'vars': vars_dict}}
@@ -183,7 +180,7 @@ def _create_hosts_auths_file(success_auth_map, profile):
         for host, line in iteritems(success_auth_map):
             string_to_write += host + '\n----------------------\n'
             for auth in line:
-                string_to_write += format_auth_for_host_auth_mapping(auth)
+                string_to_write += redacted_auth_string(auth)
             string_to_write += '\n\n'
         string_to_write += '\n*******************************' \
                            '*********************************' \
@@ -203,7 +200,7 @@ def make_inventory_dict(success_hosts, success_port_map, auth_map):
     :param success_hosts: a list of hosts for the inventory
     :param success_port_map: mapping from hosts to SSH ports
     :param auth_map: map from host IP to a list of auths it works with
-    
+
     :returns: a dict with the structure
     {'alpha':
       {'hosts'
@@ -227,7 +224,7 @@ def make_inventory_dict(success_hosts, success_port_map, auth_map):
     yml_dict['alpha'] = {'hosts': alpha_hosts}
 
     return yml_dict
-    
+
 
 def _create_main_inventory(vault, success_hosts, success_port_map,
                            auth_map, profile):

--- a/rho/scancommand.py
+++ b/rho/scancommand.py
@@ -99,8 +99,6 @@ def _create_ping_inventory(vault, vault_pass, profile_ranges, profile_port,
 
     :returns: a tuple of
       (list of IP addresses that worked for any auth,
-       map from host IPs to a list of all auths that worked with
-         that host,
        map from host IPs to SSH ports that worked with them,
        map from host IPs to lists of auths that worked with them
       )

--- a/test/test_scan_command.py
+++ b/test/test_scan_command.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2017 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+"""Unit tests for the scan command."""
+
+# This file has tests for specific functions in rho.scancommand, but
+# does not actually call ScanCommand.main(). The tests that do call
+# main are in test_clicommand.py, becuase that's where the
+# infrastructure for mocking out credentials and profiles is.
+
+import unittest
+import mock
+
+from rho import scancommand
+
+
+class TestScanCommand(unittest.TestCase):
+    def test_make_inventory_dict_one_host(self):
+        auth_item = [
+            '1',       # ID
+            'auth_1',  # name
+            'user',    # username
+            'pass',    # password
+            'sshkey']  # ssh_key_file
+        self.assertEqual(
+            scancommand.make_inventory_dict(
+                ['host_ip_1'],                       # success_map
+                {'host_ip_1': '22'},                 # success_port_map
+                {tuple(auth_item): ['host_ip_1']}),  # best_map
+            {'alpha':
+             {'hosts':
+              {'host_ip_1':
+               {'ansible_host': 'host_ip_1',
+                'ansible_port': '22',
+                'ansible_user': 'user',
+                'ansible_ssh_pass': 'pass',
+                'ansible_ssh_private_key_file': 'sshkey'}}}})

--- a/test/test_scan_command.py
+++ b/test/test_scan_command.py
@@ -7,7 +7,7 @@
 # along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
-"""Unit tests for the scan command."""
+"""Unit tests for scancommand.py."""
 
 # This file has tests for specific functions in rho.scancommand, but
 # does not actually call ScanCommand.main(). The tests that do call
@@ -19,8 +19,13 @@ import unittest
 from rho import scancommand
 
 
+# pylint: disable=invalid-name
 class TestScanCommand(unittest.TestCase):
+    """Unit tests for scancommand.py."""
+
     def test_make_inventory_dict_one_host(self):
+        """Test scancommand.make_inventory_dict with just one host."""
+
         auth = {
             'id': '1',
             'name': 'auth_1',

--- a/test/test_scan_command.py
+++ b/test/test_scan_command.py
@@ -15,24 +15,23 @@
 # infrastructure for mocking out credentials and profiles is.
 
 import unittest
-import mock
 
 from rho import scancommand
 
 
 class TestScanCommand(unittest.TestCase):
     def test_make_inventory_dict_one_host(self):
-        auth_item = [
-            '1',       # ID
-            'auth_1',  # name
-            'user',    # username
-            'pass',    # password
-            'sshkey']  # ssh_key_file
+        auth = {
+            'id': '1',
+            'name': 'auth_1',
+            'username': 'user',
+            'password': 'pass',
+            'ssh_key_file': 'sshkey'}
         self.assertEqual(
             scancommand.make_inventory_dict(
-                ['host_ip_1'],                       # success_map
-                {'host_ip_1': '22'},                 # success_port_map
-                {tuple(auth_item): ['host_ip_1']}),  # best_map
+                ['host_ip_1'],           # success_hosts
+                {'host_ip_1': '22'},     # success_port_map
+                {'host_ip_1': [auth]}),  # auth_map
             {'alpha':
              {'hosts':
               {'host_ip_1':


### PR DESCRIPTION
Get ready for sudo password support by refactoring and simplifying the scan command. Big changes:
  - move Ansible inventory generation to a separate function than inventory output, which makes it possible to unit test the inventory generation
  - remove duplicate code by making a single function that expresses a Rho auth as Ansible host vars
  - simplify the data flow from the ping inventory to the main inventory
  - add some debug log statements. Thanks to the earlier -v PR, these will only display when the user asks for verbose output, so I think it's okay to have them in the codebase