### PR TITLE
Drop python-future requirement for split_results

### DIFF
--- a/library/spit_results.py
+++ b/library/spit_results.py
@@ -18,13 +18,13 @@ import os
 import json
 import sys
 import xml
-from past.builtins import long  # pylint: disable=redefined-builtin
 # pylint: disable=import-error
 from ansible.module_utils.basic import AnsibleModule
 
 # for parsing systemid
 if sys.version_info > (3,):
     import xmlrpc.client as xmlrpclib  # pylint: disable=import-error
+    long = int  # pylint: disable=invalid-name,redefined-builtin
 else:
     import xmlrpclib  # pylint: disable=import-error
 


### PR DESCRIPTION
split_results does not need to import python-future's past module if
`long` is made equals to `int` on Python 3. Doing that allows dropping
the python-future requirement and make split_results able to run without
any extra python package being required.

Closes #137