### PR TITLE
Add version support for rho that also includes ansible and python version info. Closes #161.

### DIFF
--- a/rho/__init__.py
+++ b/rho/__init__.py
@@ -1,0 +1,2 @@
+# pylint: disable=missing-docstring
+__version__ = '0.0.28'

--- a/rho/cli.py
+++ b/rho/cli.py
@@ -19,6 +19,8 @@ from __future__ import print_function
 import sys
 import os
 import inspect
+import ansible
+import rho
 from rho.clicommand import CliCommand
 from rho.authaddcommand import AuthAddCommand  # noqa
 from rho.authclearcommand import AuthClearCommand  # noqa
@@ -116,6 +118,11 @@ class CLI(object):
         if len_sys_argv < 2 or not self._find_best_match(sys.argv):
             if len_sys_argv == 2 and sys.argv[1] == '--help':
                 self._usage()
+                sys.exit(0)
+            elif len_sys_argv == 2 and sys.argv[1] == '--version':
+                print('version: ' + rho.__version__)
+                print('\tansible: ' + ansible.__version__)
+                print('\tpython: ' + sys.version)
                 sys.exit(0)
             else:
                 self._usage()

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ import subprocess
 
 from setuptools import setup, find_packages
 from setuptools import Command
+from rho import __version__
 
 
 class BuildLangs(Command):
@@ -91,7 +92,7 @@ def get_data_files():
 
 setup(
     name="rho",
-    version='0.0.28',
+    version=__version__,
     description='Network scanner to identify operating systems and versions.',
     author='Red Hat',
     author_email='',


### PR DESCRIPTION
```
~/Code/rho$ rho --version
version:0.0.28
	ansible:2.3.1.0
	python:2.7.13 (default, Apr  4 2017, 08:47:57) 
[GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.38)]
```