### PR TITLE
Scrape subman output properly when ssh'ing with a password

### DIFF
--- a/roles/subman/tasks/main.yml
+++ b/roles/subman/tasks/main.yml
@@ -13,7 +13,7 @@
 
 - name: add subman.cpu.cpu(s) to dictionary
   set_fact:
-    subman: "{{ subman|default({}) | combine({ item: subman_cpu_cpu['stdout_lines'][0] | default('error') }) }}"
+    subman: "{{ subman|default({}) | combine({ item: subman_cpu_cpu['stdout'] | trim | default('error') }) }}"
   with_items:
   - 'subman.cpu.cpu(s)'
   when: '"subman.cpu.cpu(s)" in facts_to_collect'
@@ -27,7 +27,7 @@
 
 - name: add subman.cpu.core(s)_per_socket to dictionary
   set_fact:
-    subman: "{{ subman|default({}) | combine({ item: subman_cpu_core_per_socket['stdout_lines'][0] | default('error') }) }}"
+    subman: "{{ subman|default({}) | combine({ item: subman_cpu_core_per_socket['stdout'] | trim | default('error') }) }}"
   with_items:
   - 'subman.cpu.core(s)_per_socket'
   when: '"subman.cpu.core(s)_per_socket" in facts_to_collect'
@@ -41,7 +41,7 @@
 
 - name: add subman.cpu.cpu_socket(s) to dictionary
   set_fact:
-    subman: "{{ subman|default({}) | combine({ item: subman_cpu_cpu_socket['stdout_lines'][0] | default('error') }) }}"
+    subman: "{{ subman|default({}) | combine({ item: subman_cpu_cpu_socket['stdout'] | trim | default('error') }) }}"
   with_items:
   - 'subman.cpu.cpu_socket(s)'
   when: '"subman.cpu.cpu_socket(s)" in facts_to_collect'
@@ -55,7 +55,7 @@
 
 - name: add subman.virt.host_type to dictionary
   set_fact:
-    subman: "{{ subman|default({}) | combine({ item: subman_virt_host_type['stdout_lines'][0] | default('error') }) }}"
+    subman: "{{ subman|default({}) | combine({ item: subman_virt_host_type['stdout'] | trim | default('error') }) }}"
   with_items:
   - 'subman.virt.host_type'
   when: '"subman.virt.host_type" in facts_to_collect'
@@ -69,7 +69,7 @@
 
 - name: add subman.virt.is_guest to dictionary
   set_fact:
-    subman: "{{ subman|default({}) | combine({ item: subman_virt_is_guest['stdout_lines'][0] | default('error') }) }}"
+    subman: "{{ subman|default({}) | combine({ item: subman_virt_is_guest['stdout'] | trim | default('error') }) }}"
   with_items:
   - 'subman.virt.is_guest'
   when: '"subman.virt.is_guest" in facts_to_collect'
@@ -83,7 +83,7 @@
 
 - name: add subman.virt.uuid to dictionary
   set_fact:
-    subman: "{{ subman|default({}) | combine({ item: subman_virt_uuid['stdout_lines'][0] | default('error') }) }}"
+    subman: "{{ subman|default({}) | combine({ item: subman_virt_uuid['stdout'] | trim | default('error') }) }}"
   with_items:
   - 'subman.virt.uuid'
   when: '"subman.virt.uuid" in facts_to_collect'
@@ -96,7 +96,7 @@
 
 - name: add subman.has_facts_file to dictionary
   set_fact:
-    subman: "{{ subman|default({}) | combine({ item: subman_has_facts_file['stdout_lines'][0] | default('error') }) }}"
+    subman: "{{ subman|default({}) | combine({ item: subman_has_facts_file['stdout'] | trim | default('error') }) }}"
   with_items:
   - 'subman.has_facts_file'
   when: '"subman.has_facts_file" in facts_to_collect'


### PR DESCRIPTION
Need to use output['stdout'] | trim instead of
output['stdout_lines'][0].

Closes #207 .