### PR TITLE
Fix file modes for Python 3

### DIFF
--- a/rho/factdecryptcommand.py
+++ b/rho/factdecryptcommand.py
@@ -87,7 +87,7 @@ class FactDecryptCommand(CliCommand):
         data = []
         keys = None
 
-        with open(path, 'rb') as read_file:
+        with open(path, 'r') as read_file:
             reader = csv.DictReader(read_file, delimiter=',')
             for row in reader:
                 for fact in self.facts_to_decrypt:

--- a/rho/factencryptcommand.py
+++ b/rho/factencryptcommand.py
@@ -87,7 +87,7 @@ class FactEncryptCommand(CliCommand):
         data = []
         keys = None
 
-        with open(path, 'rb') as read_file:
+        with open(path, 'r') as read_file:
             reader = csv.DictReader(read_file, delimiter=',')
             for row in reader:
                 for fact in self.facts_to_encrypt:

--- a/rho/factredactcommand.py
+++ b/rho/factredactcommand.py
@@ -81,7 +81,7 @@ class FactRedactCommand(CliCommand):
         data = []
         keys = None
         normalized_path = os.path.normpath(self.options.report_path)
-        with open(normalized_path, 'rb') as read_file:
+        with open(normalized_path, 'r') as read_file:
             reader = csv.DictReader(read_file, delimiter=',')
             for row in reader:
                 for fact in self.facts_to_redact:
@@ -100,7 +100,7 @@ class FactRedactCommand(CliCommand):
             print(_("Fact %s was not present in %s" %
                     (fact, self.options.report_path)))
 
-        with tempfile.NamedTemporaryFile(mode='wb', delete=False) as data_temp:
+        with tempfile.NamedTemporaryFile(mode='w', delete=False) as data_temp:
             # Construct the CSV writer
             writer = csv.DictWriter(
                 data_temp, fieldnames=sorted(keys), delimiter=',')

--- a/rho/utilities.py
+++ b/rho/utilities.py
@@ -245,7 +245,7 @@ def write_csv_data(keys, data, path):
     :param data: The dictionary of data to convert to csv
     :param path: The file path to write to
     """
-    with tempfile.NamedTemporaryFile(mode='wb', delete=False) as data_temp:
+    with tempfile.NamedTemporaryFile(mode='w', delete=False) as data_temp:
         # Construct the CSV writer
         writer = csv.DictWriter(
             data_temp, fieldnames=sorted(keys), delimiter=',')

--- a/rho/vault.py
+++ b/rho/vault.py
@@ -127,6 +127,7 @@ class Vault(object):
         """ Convert object to json and encrypt the data.
         :param obj: Python object to convert to json
         :param stream: If not None the location to write the encrypted data to.
+          If this is a file in Python 3, it must be open in binary mode.
         :returns: If stream is None then the encrypted bytes otherwise None.
         """
         data = json.dumps(obj, separators=(',', ': '))
@@ -137,7 +138,7 @@ class Vault(object):
         :param obj: Python object to convert to json
         :param file_path: The file to write data to via temp file
         """
-        with tempfile.NamedTemporaryFile(mode='wb', delete=False) as data_temp:
+        with tempfile.NamedTemporaryFile(delete=False) as data_temp:
             self.dump_as_json(obj, data_temp)
         data_temp.close()
         move(data_temp.name, os.path.abspath(file_path))
@@ -156,7 +157,7 @@ class Vault(object):
         :param obj: Python object to convert to yaml
         :param file_path: The file to write data to via temp file
         """
-        with tempfile.NamedTemporaryFile(mode='wb', delete=False) as data_temp:
+        with tempfile.NamedTemporaryFile(mode='w', delete=False) as data_temp:
             self.dump_as_yaml(obj, data_temp)
         data_temp.close()
         move(data_temp.name, os.path.abspath(file_path))

--- a/test/test_clicommand.py
+++ b/test/test_clicommand.py
@@ -208,7 +208,7 @@ class CliCommandsTests(unittest.TestCase):
                        'date.machine_id': '2017-07-18',
                        'jboss.installed-versions': 'WildFly-10',
                        'uname.hardware_platform': 'x86_64'}]
-            with open(TMP_TEST_REPORT_SENSITIVE, 'wb') as data_temp:
+            with open(TMP_TEST_REPORT_SENSITIVE, 'w') as data_temp:
                 writer = csv.DictWriter(data_temp,
                                         fieldnames=sorted(report_keys),
                                         delimiter=',')


### PR DESCRIPTION
Encrypted data files need to be in binary mode, and non-encrypted CSV
files need to be in text mode under Python 3.

This change may break support for Windows as the controller, but we
don't currently have any way to test that, so it's probably broken
anyway and definitely unsupported. If we do get a way to test Windows,
this change doesn't make it any harder to use the OS to choose the
file mode.

Closes #223 .