### PR TITLE
Add 'become: yes' to more Ansible commands

### DIFF
--- a/doc/command_syntax_usage.rst
+++ b/doc/command_syntax_usage.rst
@@ -182,8 +182,13 @@ scan does not have the appropriate permissions to execute the command used to
 gather the targeted facts. The following set of facts require *admin/root*
 permissions to collect the facts:
 
+- ``cpu.socket_count``
+- ``date.anaconda_log``
+- ``date.yum_history``
 - ``dmi.x``
 - ``subman.x``
+- ``virt.virt``
+- ``virt.type``
 - ``virt-what.x``
 
 The scan user can successful collect these values if the user is **root** or

--- a/roles/cpu/tasks/main.yml
+++ b/roles/cpu/tasks/main.yml
@@ -83,14 +83,15 @@
   when: '"cpu.count" in facts_to_collect'
 
 - name: gather cpu.socket_count fact
-  raw: sudo -n /usr/sbin/dmidecode -t 4 | grep 'Socket Designation'| wc -l
+  raw: /usr/sbin/dmidecode -t 4 | grep 'Socket Designation'| wc -l
   register: cpu_socket_count
+  become: yes
   ignore_errors: yes
   when: '"cpu.socket_count" in facts_to_collect'
 
 - name: add cpu.socket_count to dictionary
   set_fact:
-    cpu: "{{ cpu|default({}) | combine({ item: cpu_socket_count['stdout_lines'][0] | default('error') }) }}"
+    cpu: "{{ cpu|default({}) | combine({ item: cpu_socket_count['stdout'] | trim | default('error') }) }}"
   with_items:
   - 'cpu.socket_count'
   when: '"cpu.socket_count" in facts_to_collect'

--- a/roles/date/tasks/main.yml
+++ b/roles/date/tasks/main.yml
@@ -20,12 +20,13 @@
 - name: gather date.anaconda_log fact
   raw: ls --full-time /root/anaconda-ks.cfg | grep -o '[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}'
   register: date_anaconda_log
+  become: yes
   ignore_errors: yes
   when: '"date.anaconda_log" in facts_to_collect'
 
 - name: add date.anaconda_log to dictionary
   set_fact:
-    date: "{{ date|default({}) | combine({ item: date_anaconda_log['stdout_lines'][0] | default('error') }) }}"
+    date: "{{ date|default({}) | combine({ item: date_anaconda_log['stdout'] | trim | default('error') }) }}"
   with_items:
   - 'date.anaconda_log'
   when: '"date.anaconda_log" in facts_to_collect'
@@ -59,12 +60,13 @@
 - name: gather date.yum_history fact
   raw: yum history | tail -n 4 | grep -o '[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}'
   register: date_yum_history
+  become: yes
   ignore_errors: yes
   when: '"date.yum_history" in facts_to_collect'
 
 - name: add date.yum_history to dictionary
   set_fact:
-    date: "{{ date|default({}) | combine({ item: date_yum_history['stdout_lines'][0] | default('error') }) }}"
+    date: "{{ date|default({}) | combine({ item: date_yum_history['stdout_lines'] | select | first | default('error') }) }}"
   with_items:
   - 'date.yum_history'
   when: '"date.yum_history" in facts_to_collect'

--- a/roles/virt/tasks/main.yml
+++ b/roles/virt/tasks/main.yml
@@ -29,26 +29,30 @@
   when: '"virt.virt" in facts_to_collect or "virt.type" in facts_to_collect'
 
 - name: check system manufacture for VMware
-  raw: manufacturer=$(sudo -n /usr/sbin/dmidecode | grep -A4 'System Information' | grep 'Manufacturer' | sed -n -e 's/^.*Manufacturer:\s//p'); if [[ $manufacturer == *"VMware"* ]]; then echo "Y"; else echo "N"; fi
+  raw: manufacturer=$(/usr/sbin/dmidecode | grep -A4 'System Information' | grep 'Manufacturer' | sed -n -e 's/^.*Manufacturer:\s//p'); if [[ $manufacturer == *"VMware"* ]]; then echo "Y"; else echo "N"; fi
   register: sys_manu_vmware
+  become: yes
   ignore_errors: yes
   when: '"virt.virt" in facts_to_collect or "virt.type" in facts_to_collect'
 
 - name: check system manufacture for innotek GmbH
-  raw: manufacturer=$(sudo -n /usr/sbin/dmidecode | grep -A4 'System Information' | grep 'Manufacturer' | sed -n -e 's/^.*Manufacturer:\s//p'); if [[ $manufacturer == *"innotek GmbH"* ]]; then echo "Y"; else echo "N"; fi
+  raw: manufacturer=$(/usr/sbin/dmidecode | grep -A4 'System Information' | grep 'Manufacturer' | sed -n -e 's/^.*Manufacturer:\s//p'); if [[ $manufacturer == *"innotek GmbH"* ]]; then echo "Y"; else echo "N"; fi
   register: sys_manu_virtualbox
+  become: yes
   ignore_errors: yes
   when: '"virt.virt" in facts_to_collect or "virt.type" in facts_to_collect'
 
 - name: check system manufacture for Microsoft
-  raw: manufacturer=$(sudo -n /usr/sbin/dmidecode | grep -A4 'System Information' | grep 'Manufacturer' | sed -n -e 's/^.*Manufacturer:\s//p'); if [[ $manufacturer == *"Microsoft"* ]]; then echo "Y"; else echo "N"; fi
+  raw: manufacturer=$(/usr/sbin/dmidecode | grep -A4 'System Information' | grep 'Manufacturer' | sed -n -e 's/^.*Manufacturer:\s//p'); if [[ $manufacturer == *"Microsoft"* ]]; then echo "Y"; else echo "N"; fi
   register: sys_manu_virtualpc
+  become: yes
   ignore_errors: yes
   when: '"virt.virt" in facts_to_collect or "virt.type" in facts_to_collect'
 
 - name: check system manufacture for QEMU
-  raw: manufacturer=$(sudo -n /usr/sbin/dmidecode | grep -A4 'System Information' | grep 'Manufacturer' | sed -n -e 's/^.*Manufacturer:\s//p'); if [[ $manufacturer == *"QEMU"* ]]; then echo "Y"; else echo "N"; fi
+  raw: manufacturer=$(/usr/sbin/dmidecode | grep -A4 'System Information' | grep 'Manufacturer' | sed -n -e 's/^.*Manufacturer:\s//p'); if [[ $manufacturer == *"QEMU"* ]]; then echo "Y"; else echo "N"; fi
   register: sys_manu_kvm
+  become: yes
   ignore_errors: yes
   when: '"virt.virt" in facts_to_collect or "virt.type" in facts_to_collect'
 


### PR DESCRIPTION
This makes Rho work properly when a command needs sudo permissions and
the auth has a sudo password. Also update the docs to list more
commands that need sudo permissions.

The problem in #216 is that some of the tasks which need sudo permission didn't use `become: true`, which means they didn't use the sudo password even when Ansible knew it. I ran a full scan from a user with no sudo password and found a few more tasks that weren't listed in #216 , but I wasn't able to test tasks that are conditional on other tasks, so there are potentially more problems like this out there.

Closes #216 .