### PR TITLE
Update dump_as_yaml_to_file

### DIFF
--- a/rho/vault.py
+++ b/rho/vault.py
@@ -157,7 +157,7 @@ class Vault(object):
         :param obj: Python object to convert to yaml
         :param file_path: The file to write data to via temp file
         """
-        with tempfile.NamedTemporaryFile(mode='w', delete=False) as data_temp:
+        with tempfile.NamedTemporaryFile(delete=False) as data_temp:
             self.dump_as_yaml(obj, data_temp)
         data_temp.close()
         move(data_temp.name, os.path.abspath(file_path))


### PR DESCRIPTION
Create the temporary file as binary because `vault.decrypt` returns
bytes and not string.

Closes #235