### PR TITLE
Issues/153

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ lint-flake8-3:
 	python3 -m flake8 . --ignore D203 --exclude fact_docs.py
 
 lint-pylint-3:
-	python3 -m pylint --disable=duplicate-code,locally-disabled */*.py -rn
+	python3 -m pylint --disable=duplicate-code,locally-disabled,bad-option-value */*.py -rn
 
 lint-3: lint-flake8-3 lint-pylint-3
 

--- a/doc/command_syntax_usage.rst
+++ b/doc/command_syntax_usage.rst
@@ -38,9 +38,9 @@ over SSH. Each authentication identity requires its own auth entry.
 
 *Note:* --password not being passed or passed as empty are considered the same thing.
 
----------------------------
-Password-protected SSH key
----------------------------
+-------------------------
+SSH Key with a Passphrase
+-------------------------
 
 There are two ways to handle password-protected ssh keys. If a
 password-protected ssh key is specified and the key is not present in

--- a/doc/command_syntax_usage.rst
+++ b/doc/command_syntax_usage.rst
@@ -38,6 +38,20 @@ over SSH. Each authentication identity requires its own auth entry.
 
 *Note:* --password not being passed or passed as empty are considered the same thing.
 
+---------------------------
+Password-protected SSH key
+---------------------------
+
+There are two ways to handle password-protected ssh keys. If a
+password-protected ssh key is specified and the key is not present in
+the ssh agent, then Rho will prompt the user for the key password each
+time it needs to use the key.
+
+To avoid repetitive prompts, users can add their keys to the local ssh
+agent (as documented at
+http://docs.ansible.com/ansible/latest/intro_getting_started.html),
+which will decrypt them once and make them available to Rho.
+
 ^^^^^^^^^
 Profiles
 ^^^^^^^^^

--- a/rho/scancommand.py
+++ b/rho/scancommand.py
@@ -20,9 +20,9 @@ import re
 import time
 import json
 from collections import defaultdict
+from getpass import getpass
 import pexpect
 import yaml
-from getpass import getpass
 from rho import utilities
 from rho.clicommand import CliCommand
 from rho.vault import get_vault_and_password


### PR DESCRIPTION
Support ssh key files with passphrases

This ended up being some relatively small changes to how we use pexpect, but figuring out which small changes we needed took a long time.

One thing that is not in this PR (yet) is the changes to `Vagrantfile` that I used to test this, because I haven't figured out how to make them portable yet. I'm not sure if they need to be in this PR, but I do want to merge them eventually.