### PR TITLE
Eliminate Python from the ping inventory

### DIFF
--- a/test/test_scan_command.py
+++ b/test/test_scan_command.py
@@ -45,3 +45,16 @@ class TestScanCommand(unittest.TestCase):
                 'ansible_user': 'user',
                 'ansible_ssh_pass': 'pass',
                 'ansible_ssh_private_key_file': 'sshkey'}}}})
+
+    def test_process_ping_output(self):
+        """The output of a three-host scan"""
+
+        self.assertEqual(
+            scancommand.process_ping_output([
+                '192.168.50.11 | SUCCESS | rc=0 >>',
+                'Hello',
+                '192.168.50.12 | SUCCESS | rc=0 >>',
+                'Hello',
+                '192.168.50.10 | SUCCESS | rc=0 >>',
+                'Hello']),
+            set(['192.168.50.10', '192.168.50.11', '192.168.50.12']))


### PR DESCRIPTION
This completely breaks our dependence on Python on the remote
machine. Instead of running a test Python program on remote hosts to
see if we can reach them and authenticate successfully, run 'echo
"Hello"'.

Also pull the ping log scanning into its own function so it can be unit tested. Closes #191.