### PR TITLE
Better error messages for missing programs

### DIFF
--- a/doc/command_syntax_usage.rst
+++ b/doc/command_syntax_usage.rst
@@ -217,3 +217,13 @@ If the scan user uses a password to sudo, one can be given with the
 `--sudo-password` option to the `auth add` and `auth edit`
 commands. The sudo-with-password fundtionality can be tested by using
 the 'askpass' box in the Vagrantfile.
+
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Programs on Remote Machines
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Besides standard Unix utilities, some Rho fact collectors depend on
+specific programs being installed on the machines being scanned. THe
+complete list is at `remote programs
+<github.com/quipucords/rho/doc/remote_programs.rst>`.
+

--- a/doc/remote_programs.rst
+++ b/doc/remote_programs.rst
@@ -1,0 +1,79 @@
+---------------
+Remote Programs
+---------------
+
+This file documents which programs on the remote host are used to
+collect different groups of facts. **bold** is used for executables
+that are not standard Unix programs (i.e. not grep, sed, etc.). In
+addition to the programs below, we depend on standard shell facilities
+like those provided by bash.
+
+- brms.*
+  - find
+  - sed
+  - sort
+  - grep / egrep
+- cpu.*
+  - cat
+  - grep
+  - sed
+  - wc
+  - **/usr/sbin/dmidecode**
+- date.*
+  - date
+  - ls
+  - grep / egrep
+  - **tune2fs**
+  - mount
+  - sed
+  - **yum**
+  - tail
+- dmi.*
+  - **/usr/sbin/dmidecode**
+  - grep
+  - sed
+- etc_release.*
+  - cat
+  - uname
+- file_contents.*
+  - cat
+- jboss.fuse.*
+  - find
+  - sed
+  - sort
+  - echo
+- jboss.* (facts one level down from jboss)
+  - find
+  - grep
+  - **java**
+  - sed
+  - stat
+  - df
+  - tail
+  - ls
+  - sort
+- redhat_packages
+  - **rpm**
+- redhat_release.*
+  - **rpm**
+- subman.*
+  - **subscription-manager**
+  - grep
+  - sed
+  - ls
+  - wc
+- uname.*
+  - uname
+- virt.*
+  - command
+  - **virsh**
+  - ps
+  - grep
+  - wc
+  - **/usr/sbin/dmidecode**
+  - sed
+  - cat
+- virt_what.*
+  - command
+  - **virt-what**
+  - echo

--- a/library/spit_results.py
+++ b/library/spit_results.py
@@ -144,6 +144,8 @@ def safe_next(iterator):
 def process_jboss_versions(host_vars):
     """Get JBoss version information from the host_vars."""
 
+    running_ver = 'jboss.running-versions'
+
     lines = []
     val = {}
 
@@ -156,7 +158,6 @@ def process_jboss_versions(host_vars):
     if 'jboss.run-jar-ver' in host_vars:
         lines.extend(host_vars['jboss.run-jar-ver']['stdout_lines'])
     if 'jboss.running-versions' in host_vars:
-        running_ver = 'jboss.running-versions'
         val[running_ver] = host_vars[running_ver]['stdout']
 
     jboss_releases = []
@@ -172,11 +173,16 @@ def process_jboss_versions(host_vars):
             elif version.strip():
                 jboss_releases.append('Unknown-Release: ' + version)
 
-    if not jboss_releases:
-        return val
+    if jboss_releases:
+        val['jboss.installed-versions'] = '; '.join(jboss_releases)
+        val['jboss.deploy-dates'] = '; '.join(deploy_dates)
 
-    val['jboss.installed-versions'] = '; '.join(jboss_releases)
-    val['jboss.deploy-dates'] = '; '.join(deploy_dates)
+    # The jboss role will not run if 'have_java' is false.
+    if not host_vars['have_java']:
+        val['jboss.installed-versions'] = 'N/A (java not found)'
+        val['jboss.deploy-dates'] = 'N/A (java not found)'
+        val[running_ver] = 'N/A (java not found)'
+
     return val
 
 

--- a/rho_playbook.yml
+++ b/rho_playbook.yml
@@ -8,6 +8,7 @@
   hosts: all
   gather_facts: no
   roles:
+    - check_dependencies
     - connection
     - cpu
     - date

--- a/roles/check_dependencies/tasks/main.yml
+++ b/roles/check_dependencies/tasks/main.yml
@@ -1,0 +1,73 @@
+---
+
+- name: gather have_dmidecode_raw
+  raw: command -v /usr/sbin/dmidecode
+  register: have_dmidecode_raw
+  ignore_errors: yes
+
+- name: set have_dmidecode
+  set_fact:
+    have_dmidecode: "{{ have_dmidecode_raw.rc == 0 }}"
+
+- name: gather have_tune2fs_raw
+  raw: command -v tune2fs
+  register: have_tune2fs_raw
+  ignore_errors: yes
+
+- name: set have_tune2fs
+  set_fact:
+    have_tune2fs: "{{ have_tune2fs_raw.rc == 0 }}"
+
+- name: gather have_yum_raw
+  raw: command -v yum
+  register: have_yum_raw
+  ignore_errors: yes
+
+- name: set have_yum
+  set_fact:
+    have_yum: "{{ have_yum_raw.rc == 0 }}"
+
+- name: gather have_java_raw
+  raw: command -v java
+  register: have_java_raw
+  ignore_errors: yes
+
+- name: set have_java
+  set_fact:
+    have_java: "{{ have_java_raw.rc == 0 }}"
+
+- name: gather have_rpm_raw
+  raw: command -v rpm
+  register: have_rpm_raw
+  ignore_errors: yes
+
+- name: set have_rpm
+  set_fact:
+    have_rpm: "{{ have_rpm_raw.rc == 0 }}"
+
+- name: gather have_subscription_manager_raw
+  raw: command -v subscription-manager
+  register: have_subscription_manager_raw
+  ignore_errors: yes
+
+- name: set have_subscription_manager
+  set_fact:
+    have_subscription_manager: "{{ have_subscription_manager_raw.rc == 0 }}"
+
+- name: gather have_virsh_raw
+  raw: command -v virsh
+  register: have_virsh_raw
+  ignore_errors: yes
+
+- name: set have_virsh
+  set_fact:
+    have_virsh: "{{ have_virsh_raw.rc == 0 }}"
+
+- name: gather have_virt_what_raw
+  raw: command -v virt-what
+  register: have_virt_what_raw
+  ignore_errors: yes
+
+- name: set have_virt_what
+  set_fact:
+    have_virt_what: "{{ have_virt_what_raw.rc == 0 }}"

--- a/roles/cpu/tasks/main.yml
+++ b/roles/cpu/tasks/main.yml
@@ -87,11 +87,11 @@
   register: cpu_socket_count
   become: yes
   ignore_errors: yes
-  when: '"cpu.socket_count" in facts_to_collect'
+  when: 'have_dmidecode and "cpu.socket_count" in facts_to_collect'
 
 - name: add cpu.socket_count to dictionary
   set_fact:
-    cpu: "{{ cpu|default({}) | combine({ item: cpu_socket_count['stdout'] | trim | default('error') }) }}"
+    cpu: "{{ cpu|default({}) | combine({ item: cpu_socket_count['stdout'] | trim | default('error') if have_dmidecode else 'N/A (dmidecode not found)' }) }}"
   with_items:
   - 'cpu.socket_count'
   when: '"cpu.socket_count" in facts_to_collect'

--- a/roles/date/tasks/main.yml
+++ b/roles/date/tasks/main.yml
@@ -48,11 +48,11 @@
   raw: fs_date=$(tune2fs -l $(mount | egrep '/ type' | grep -o '/dev.* on' | sed -e 's/\on//g') | grep 'Filesystem created' | sed 's/Filesystem created:\s*//g'); if [[ $fs_date ]]; then date +'%F' -d \"$fs_date\"; else echo "" ; fi
   register: date_filesystem_create
   ignore_errors: yes
-  when: '"date.filesystem_create" in facts_to_collect'
+  when: 'have_tune2fs and "date.filesystem_create" in facts_to_collect'
 
 - name: add date.filesystem_create to dictionary
   set_fact:
-    date: "{{ date|default({}) | combine({ item: date_filesystem_create['stdout_lines'][0] | default('error') }) }}"
+    date: "{{ date|default({}) | combine({ item: date_filesystem_create['stdout_lines'][0] | default('error') if have_tune2fs else 'N/A (tune2fs not found)' }) }}"
   with_items:
   - 'date.filesystem_create'
   when: '"date.filesystem_create" in facts_to_collect'
@@ -62,11 +62,11 @@
   register: date_yum_history
   become: yes
   ignore_errors: yes
-  when: '"date.yum_history" in facts_to_collect'
+  when: 'have_yum and "date.yum_history" in facts_to_collect'
 
 - name: add date.yum_history to dictionary
   set_fact:
-    date: "{{ date|default({}) | combine({ item: date_yum_history['stdout_lines'] | select | first | default('error') }) }}"
+    date: "{{ date|default({}) | combine({ item: date_yum_history['stdout_lines'] | select | first | default('error') if have_yum else 'N/A (yum not found)' }) }}"
   with_items:
   - 'date.yum_history'
   when: '"date.yum_history" in facts_to_collect'

--- a/roles/dmi/tasks/main.yml
+++ b/roles/dmi/tasks/main.yml
@@ -13,7 +13,7 @@
 
 - name: add dmi.bios-vendor to dictionary
   set_fact:
-    dmi: "{{ dmi|default({}) | combine({ item: dmi_bios_vendor['stdout'] | trim | default('error') }) }}"
+    dmi: "{{ dmi|default({}) | combine({ item: dmi_bios_vendor['stdout'] | trim | default('error') if have_dmidecode else 'N/A (dmidecode not found)' }) }}"
   with_items:
   - 'dmi.bios-vendor'
   when: '"dmi.bios-vendor" in facts_to_collect'
@@ -27,7 +27,7 @@
 
 - name: add dmi.bios-version to dictionary
   set_fact:
-    dmi: "{{ dmi|default({}) | combine({ item: dmi_bios_version['stdout'] | trim | default('error') }) }}"
+    dmi: "{{ dmi|default({}) | combine({ item: dmi_bios_version['stdout'] | trim | default('error') if have_dmidecode else 'N/A (dmidecode not found)' }) }}"
   with_items:
   - 'dmi.bios-version'
   when: '"dmi.bios-version" in facts_to_collect'
@@ -41,7 +41,7 @@
 
 - name: add dmi.system-manufacturer to dictionary
   set_fact:
-    dmi: "{{ dmi|default({}) | combine({ item: dmi_system_manufacturer['stdout'] | trim | default('error') }) }}"
+    dmi: "{{ dmi|default({}) | combine({ item: dmi_system_manufacturer['stdout'] | trim | default('error') if have_dmidecode else 'N/A (dmidecode not found)' }) }}"
   with_items:
   - 'dmi.system-manufacturer'
   when: '"dmi.system-manufacturer" in facts_to_collect'
@@ -55,7 +55,7 @@
 
 - name: add dmi.processor-family to dictionary
   set_fact:
-    dmi: "{{ dmi|default({}) | combine({ item: dmi_processor_family['stdout'] | trim | default('error') }) }}"
+    dmi: "{{ dmi|default({}) | combine({ item: dmi_processor_family['stdout'] | trim | default('error') if have_dmidecode else 'N/A (dmidecode not found)' }) }}"
   with_items:
   - 'dmi.processor-family'
   when: '"dmi.processor-family" in facts_to_collect'

--- a/roles/jboss/tasks/main.yml
+++ b/roles/jboss/tasks/main.yml
@@ -5,16 +5,16 @@
       raw: FOUND=""; for jar in `find / -name 'jboss-modules.jar' 2>/dev/null | grep -v '\.installation/patches'`; do VERSION=$(java -jar ${jar} -version 2> /dev/null | grep version | sed 's/.*version\s//g'); inode=$(stat -c '%i' "${jar}"); fs=$(df  -T "${jar}" | grep "/dev" | sed 's/ .*//'); ctime=$(stat ${jar} | grep 'Change' | grep -oP '[1-2][0-9]{3}-[0-1][0-9]-[0-3][0-9]'); if [ ! -z "${VERSION}" ]; then if [ ! -z "$FOUND" ]; then FOUND="$FOUND; $VERSION**$ctime"; else FOUND=${VERSION}'**'${ctime}; fi; fi; done; echo ${FOUND}
       register: jboss.jar-ver
       ignore_errors: yes
-      when: '"jboss.installed-versions" in facts_to_collect or "jboss.deploy-dates" in facts_to_collect'
+      when: 'have_java and ("jboss.installed-versions" in facts_to_collect or "jboss.deploy-dates" in facts_to_collect)'
 
     - name: Gather jboss.run-jar-ver
       raw: FOUND=""; for jar in `find / -name 'run.jar' 2>/dev/null`; do VERSION=$(java -jar ${jar} --version 2> /dev/null | grep build  | sed 's/.*[CS]V[NS]Tag.//g' | sed 's/\sdate.*//g'); inode=$(stat -c '%i' "${jar}"); fs=$(df  -T "${jar}" | tail -1 | sed 's/ .*//'); ctime=$(stat ${jar} | grep 'Change' | grep -oP '[1-2][0-9]{3}-[0-1][0-9]-[0-3][0-9]'); if [ ! -z "${VERSION}" ]; then if [ ! -z "$FOUND" ]; then FOUND="$FOUND; $VERSION**${ctime}"; else FOUND=${VERSION}'**'${ctime}; fi; fi; done; echo ${FOUND};
       register: jboss.run-jar-ver
       ignore_errors: yes
-      when: '"jboss.installed-versions" in facts_to_collect or "jboss.deploy-dates" in facts_to_collect'
+      when: 'have_java and ("jboss.installed-versions" in facts_to_collect or "jboss.deploy-dates" in facts_to_collect)'
 
     - name: Gather jboss.running-versions
       raw: for proc_pid in $(find /proc -maxdepth 1 -name "[0-9]*"); do ls -l ${proc_pid}/fd 2>/dev/null | grep "java"; done | grep -e "/modules/system/layers/base\|/opt/rh/eap" | sed -n "s/.*\->//p" | sed -n 's/\/modules\/system\/layers\/base.*//p;s/.*\(\/opt\/rh\/eap[1-9]\).*/\1/p' | sort -u
       register: jboss.running-versions
       ignore_errors: yes
-      when: '"jboss.running-versions" in facts_to_collect'
+      when: 'have_java and "jboss.running-versions" in facts_to_collect'

--- a/roles/redhat_packages/tasks/main.yml
+++ b/roles/redhat_packages/tasks/main.yml
@@ -68,11 +68,11 @@
   raw: rpm -qa --qf "%{NAME}|%{VERSION}|%{RELEASE}|%{INSTALLTIME}|%{VENDOR}|%{BUILDTIME}|%{BUILDHOST}|%{SOURCERPM}|%{LICENSE}|%{PACKAGER}|%{INSTALLTIME:date}|%{BUILDTIME:date}\n"
   register: redhat_packages_results
   ignore_errors: yes
-  when: gather_redhat_packages
+  when: have_rpm and gather_redhat_packages
 
 - name: add redhat-packages.results to dictionary
   set_fact:
-    redhat_packages: "{{ redhat_packages|default({}) | combine({ item: redhat_packages_results['stdout_lines'] | default([]) }) }}"
+    redhat_packages: "{{ redhat_packages|default({}) | combine({ item: redhat_packages_results['stdout_lines'] | default([]) if have_rpm else 'N/A (rpm not found)' }) }}"
   with_items:
   - 'redhat-packages.results'
   when: gather_redhat_packages

--- a/roles/redhat_release/tasks/main.yml
+++ b/roles/redhat_release/tasks/main.yml
@@ -8,11 +8,11 @@
   raw: rpm -q --queryformat "%{NAME}\n" --whatprovides redhat-release
   register: redhat_release_name
   ignore_errors: yes
-  when: '"redhat-release.name" in facts_to_collect'
+  when: 'have_rpm and "redhat-release.name" in facts_to_collect'
 
 - name: add redhat-release.name to dictionary
   set_fact:
-    redhat_release: "{{ redhat_release|default({}) | combine({ item: redhat_release_name['stdout_lines'][0] | default('error') }) }}"
+    redhat_release: "{{ redhat_release|default({}) | combine({ item: redhat_release_name['stdout_lines'][0] | default('error') if have_rpm else 'N/A (rpm not found)' }) }}"
   with_items:
   - 'redhat-release.name'
   when: '"redhat-release.name" in facts_to_collect'
@@ -25,7 +25,7 @@
 
 - name: add redhat-release.version to dictionary
   set_fact:
-    redhat_release: "{{ redhat_release|default({}) | combine({ item: redhat_release_version['stdout_lines'][0] | default('error') }) }}"
+    redhat_release: "{{ redhat_release|default({}) | combine({ item: redhat_release_version['stdout_lines'][0] | default('error') if have_rpm else 'N/A (rpm not found)' }) }}"
   with_items:
   - 'redhat-release.version'
   when: '"redhat-release.version" in facts_to_collect'
@@ -38,7 +38,7 @@
 
 - name: add redhat-release.release to dictionary
   set_fact:
-    redhat_release: "{{ redhat_release|default({}) | combine({ item: redhat_release_release['stdout_lines'][0] | default('error') }) }}"
+    redhat_release: "{{ redhat_release|default({}) | combine({ item: redhat_release_release['stdout_lines'][0] | default('error') if have_rpm else 'N/A (rpm not found)' }) }}"
   with_items:
   - 'redhat-release.release'
   when: '"redhat-release.release" in facts_to_collect'

--- a/roles/subman/tasks/main.yml
+++ b/roles/subman/tasks/main.yml
@@ -9,11 +9,11 @@
   register: subman_cpu_cpu
   ignore_errors: yes
   become: yes
-  when: '"subman.cpu.cpu(s)" in facts_to_collect'
+  when: 'have_subscription_manager and "subman.cpu.cpu(s)" in facts_to_collect'
 
 - name: add subman.cpu.cpu(s) to dictionary
   set_fact:
-    subman: "{{ subman|default({}) | combine({ item: subman_cpu_cpu['stdout'] | trim | default('error') }) }}"
+    subman: "{{ subman|default({}) | combine({ item: subman_cpu_cpu['stdout'] | trim | default('error') if have_subscription_manager else 'N/A (subscription-manager not found)' }) }}"
   with_items:
   - 'subman.cpu.cpu(s)'
   when: '"subman.cpu.cpu(s)" in facts_to_collect'
@@ -23,11 +23,11 @@
   register: subman_cpu_core_per_socket
   ignore_errors: yes
   become: yes
-  when: '"subman.cpu.core(s)_per_socket" in facts_to_collect'
+  when: 'have_subscription_manager and "subman.cpu.core(s)_per_socket" in facts_to_collect'
 
 - name: add subman.cpu.core(s)_per_socket to dictionary
   set_fact:
-    subman: "{{ subman|default({}) | combine({ item: subman_cpu_core_per_socket['stdout'] | trim | default('error') }) }}"
+    subman: "{{ subman|default({}) | combine({ item: subman_cpu_core_per_socket['stdout'] | trim | default('error') if have_subscription_manager else 'N/A (subscription-manager not found)' }) }}"
   with_items:
   - 'subman.cpu.core(s)_per_socket'
   when: '"subman.cpu.core(s)_per_socket" in facts_to_collect'
@@ -37,11 +37,11 @@
   register: subman_cpu_cpu_socket
   ignore_errors: yes
   become: yes
-  when: '"subman.cpu.cpu_socket(s)" in facts_to_collect'
+  when: 'have_subscription_manager and "subman.cpu.cpu_socket(s)" in facts_to_collect'
 
 - name: add subman.cpu.cpu_socket(s) to dictionary
   set_fact:
-    subman: "{{ subman|default({}) | combine({ item: subman_cpu_cpu_socket['stdout'] | trim | default('error') }) }}"
+    subman: "{{ subman|default({}) | combine({ item: subman_cpu_cpu_socket['stdout'] | trim | default('error') if have_subscription_manager else 'N/A (subscription-manager not found)' }) }}"
   with_items:
   - 'subman.cpu.cpu_socket(s)'
   when: '"subman.cpu.cpu_socket(s)" in facts_to_collect'
@@ -51,11 +51,11 @@
   register: subman_virt_host_type
   ignore_errors: yes
   become: yes
-  when: '"subman.virt.host_type" in facts_to_collect'
+  when: 'have_subscription_manager and "subman.virt.host_type" in facts_to_collect'
 
 - name: add subman.virt.host_type to dictionary
   set_fact:
-    subman: "{{ subman|default({}) | combine({ item: subman_virt_host_type['stdout'] | trim | default('error') }) }}"
+    subman: "{{ subman|default({}) | combine({ item: subman_virt_host_type['stdout'] | trim | default('error') if have_subscription_manager else 'N/A (subscription-manager not found)' }) }}"
   with_items:
   - 'subman.virt.host_type'
   when: '"subman.virt.host_type" in facts_to_collect'
@@ -65,11 +65,11 @@
   register: subman_virt_is_guest
   ignore_errors: yes
   become: yes
-  when: '"subman.virt.is_guest" in facts_to_collect'
+  when: 'have_subscription_manager and "subman.virt.is_guest" in facts_to_collect'
 
 - name: add subman.virt.is_guest to dictionary
   set_fact:
-    subman: "{{ subman|default({}) | combine({ item: subman_virt_is_guest['stdout'] | trim | default('error') }) }}"
+    subman: "{{ subman|default({}) | combine({ item: subman_virt_is_guest['stdout'] | trim | default('error') if have_subscription_manager else 'N/A (subscription-manager not found)' }) }}"
   with_items:
   - 'subman.virt.is_guest'
   when: '"subman.virt.is_guest" in facts_to_collect'
@@ -79,11 +79,11 @@
   register: subman_virt_uuid
   ignore_errors: yes
   become: yes
-  when: '"subman.virt.uuid" in facts_to_collect'
+  when: 'have_subscription_manager and "subman.virt.uuid" in facts_to_collect'
 
 - name: add subman.virt.uuid to dictionary
   set_fact:
-    subman: "{{ subman|default({}) | combine({ item: subman_virt_uuid['stdout'] | trim | default('error') }) }}"
+    subman: "{{ subman|default({}) | combine({ item: subman_virt_uuid['stdout'] | trim | default('error') if have_subscription_manager else 'N/A (subscription-manager not found)' }) }}"
   with_items:
   - 'subman.virt.uuid'
   when: '"subman.virt.uuid" in facts_to_collect'
@@ -92,11 +92,11 @@
   raw: fact_count=$(ls /etc/rhsm/facts | grep .facts | wc -l); if [[ $fact_count > 0 ]]; then echo "Y"; else echo "N"; fi
   register: subman_has_facts_file
   ignore_errors: yes
-  when: '"subman.has_facts_file" in facts_to_collect'
+  when: 'have_subscription_manager and "subman.has_facts_file" in facts_to_collect'
 
 - name: add subman.has_facts_file to dictionary
   set_fact:
-    subman: "{{ subman|default({}) | combine({ item: subman_has_facts_file['stdout'] | trim | default('error') }) }}"
+    subman: "{{ subman|default({}) | combine({ item: subman_has_facts_file['stdout'] | trim | default('error') if have_subscription_manager else 'N/A (subscription-manager not found)' }) }}"
   with_items:
   - 'subman.has_facts_file'
   when: '"subman.has_facts_file" in facts_to_collect'

--- a/roles/virt/tasks/main.yml
+++ b/roles/virt/tasks/main.yml
@@ -4,12 +4,6 @@
   set_fact:
     virt: "{{ virt|default({}) }}"
 
-- name: check if virsh command exists
-  raw: cmd=$(command -v virsh>/dev/null); if $cmd; then echo "Y"; else echo "N"; fi
-  register: virsh_found
-  ignore_errors: yes
-  when: '"virt.virt" in facts_to_collect or "virt.type" in facts_to_collect'
-
 - name: check if privcmd exists
   raw: if [ -e /proc/xen/privcmd ]; then echo "Y"; else echo "N"; fi
   register: privcmd_found
@@ -33,28 +27,28 @@
   register: sys_manu_vmware
   become: yes
   ignore_errors: yes
-  when: '"virt.virt" in facts_to_collect or "virt.type" in facts_to_collect'
+  when: 'have_dmidecode and ("virt.virt" in facts_to_collect or "virt.type" in facts_to_collect)'
 
 - name: check system manufacture for innotek GmbH
   raw: manufacturer=$(/usr/sbin/dmidecode | grep -A4 'System Information' | grep 'Manufacturer' | sed -n -e 's/^.*Manufacturer:\s//p'); if [[ $manufacturer == *"innotek GmbH"* ]]; then echo "Y"; else echo "N"; fi
   register: sys_manu_virtualbox
   become: yes
   ignore_errors: yes
-  when: '"virt.virt" in facts_to_collect or "virt.type" in facts_to_collect'
+  when: 'have_dmidecode and ("virt.virt" in facts_to_collect or "virt.type" in facts_to_collect)'
 
 - name: check system manufacture for Microsoft
   raw: manufacturer=$(/usr/sbin/dmidecode | grep -A4 'System Information' | grep 'Manufacturer' | sed -n -e 's/^.*Manufacturer:\s//p'); if [[ $manufacturer == *"Microsoft"* ]]; then echo "Y"; else echo "N"; fi
   register: sys_manu_virtualpc
   become: yes
   ignore_errors: yes
-  when: '"virt.virt" in facts_to_collect or "virt.type" in facts_to_collect'
+  when: 'have_dmidecode and ("virt.virt" in facts_to_collect or "virt.type" in facts_to_collect)'
 
 - name: check system manufacture for QEMU
   raw: manufacturer=$(/usr/sbin/dmidecode | grep -A4 'System Information' | grep 'Manufacturer' | sed -n -e 's/^.*Manufacturer:\s//p'); if [[ $manufacturer == *"QEMU"* ]]; then echo "Y"; else echo "N"; fi
   register: sys_manu_kvm
   become: yes
   ignore_errors: yes
-  when: '"virt.virt" in facts_to_collect or "virt.type" in facts_to_collect'
+  when: 'have_dmidecode and ("virt.virt" in facts_to_collect or "virt.type" in facts_to_collect)'
 
 - name: check cpu model name for QEMU
   raw: model_name=$(cat /proc/cpuinfo | grep '^model name\s*:' | sed -n -e 's/^.*model name\s*:\s//p'); if [[ $model_name == *QEMU ]]; then echo "Y"; else echo "N"; fi
@@ -80,36 +74,43 @@
 
 - name: set virt.virt fact due to sys_manu_vmware
   set_fact: virt_virt="virt-guest"
-  when: '"virt.virt" in facts_to_collect and sys_manu_vmware["stdout_lines"][0] == "Y"'
+  when: 'have_dmidecode and "virt.virt" in facts_to_collect and sys_manu_vmware["stdout_lines"][0] == "Y"'
 
 - name: set virt.type fact due to sys_manu_vmware
   set_fact: virt_type="vmware"
-  when: '"virt.type" in facts_to_collect and sys_manu_vmware["stdout_lines"][0] == "Y"'
+  when: 'have_dmidecode and "virt.type" in facts_to_collect and sys_manu_vmware["stdout_lines"][0] == "Y"'
 
 - name: set virt.virt fact due to sys_manu_virtualbox
   set_fact: virt_virt="virt-guest"
-  when: '"virt.virt" in facts_to_collect and sys_manu_virtualbox["stdout_lines"][0] == "Y"'
+  when: 'have_dmidecode and "virt.virt" in facts_to_collect and sys_manu_virtualbox["stdout_lines"][0] == "Y"'
 
 - name: set virt.type fact due to sys_manu_virtualbox
   set_fact: virt_type="virtualbox"
-  when: '"virt.type" in facts_to_collect and sys_manu_virtualbox["stdout_lines"][0] == "Y"'
+  when: 'have_dmidecode and "virt.type" in facts_to_collect and sys_manu_virtualbox["stdout_lines"][0] == "Y"'
 
 - name: set virt.virt fact due to sys_manu_virtualpc
   set_fact: virt_virt="virt-guest"
-  when: '"virt.virt" in facts_to_collect and sys_manu_virtualpc["stdout_lines"][0] == "Y"'
+  when: 'have_dmidecode and "virt.virt" in facts_to_collect and sys_manu_virtualpc["stdout_lines"][0] == "Y"'
 
 - name: set virt.type fact due to sys_manu_virtualpc
   set_fact: virt_type="virtualpc"
-  when: '"virt.type" in facts_to_collect and sys_manu_virtualpc["stdout_lines"][0] == "Y"'
+  when: 'have_dmidecode and "virt.type" in facts_to_collect and sys_manu_virtualpc["stdout_lines"][0] == "Y"'
 
 - name: set virt.virt fact due to sys_manu_kvm
   set_fact: virt_virt="virt-guest"
-  when: '"virt.virt" in facts_to_collect and sys_manu_kvm["stdout_lines"][0] == "Y"'
+  when: 'have_dmidecode and "virt.virt" in facts_to_collect and sys_manu_kvm["stdout_lines"][0] == "Y"'
 
 - name: set virt.type fact due to sys_manu_kvm
   set_fact: virt_type="kvm"
-  when: '"virt.type" in facts_to_collect and sys_manu_kvm["stdout_lines"][0] == "Y"'
+  when: 'have_dmidecode and "virt.type" in facts_to_collect and sys_manu_kvm["stdout_lines"][0] == "Y"'
 
+- name: set virt.virt when dmidecode is not found
+  set_fact: virt_virt='N/A (dmidecode not found)'
+  when: not have_dmidecode
+
+- name: set virt.type when dmidecode is not found
+  set_fact: virt_type='N/A (dmidecode not found)'
+  when: not have_dmidecode
 
 - name: set virt.virt fact due to xen_guest
   set_fact: virt_virt="virt-guest"
@@ -139,29 +140,21 @@
   raw: virsh -c qemu:///system --readonly list --all | wc -l
   register: virt_num_guests
   ignore_errors: yes
-  when: '"virt.num_guests" in facts_to_collect and virsh_found["stdout_lines"][0] == "Y"'
+  when: '"virt.num_guests" in facts_to_collect and have_virsh'
 
 - name: extract output virt.num_guests fact
-  set_fact: virt_num_guests="{{ virt_num_guests['stdout_lines'][0] }}"
-  when: '"virt.num_guests" in facts_to_collect and virsh_found["stdout_lines"][0] == "Y"'
-
-- name: gather virt.num_guests fact
-  set_fact: virt_num_guests="error"
-  when: '"virt.num_guests" in facts_to_collect and virsh_found["stdout_lines"][0] == "N"'
+  set_fact: virt_num_guests="{{ virt_num_guests['stdout_lines'][0] if have_virsh else 'N/A (virsh not found)' }}"
+  when: '"virt.num_guests" in facts_to_collect'
 
 - name: gather virt.num_running_guests fact
   raw: virsh -c qemu:///system --readonly list --uuid | wc -l
   register: virt_num_running_guests
   ignore_errors: yes
-  when: '"virt.num_running_guests" in facts_to_collect and virsh_found["stdout_lines"][0] == "Y"'
+  when: '"virt.num_running_guests" in facts_to_collect and have_virsh'
 
 - name: extract output virt.num_running_guests fact
-  set_fact: virt_num_running_guests="{{ virt_num_running_guests['stdout_lines'][0] }}"
-  when: '"virt.num_running_guests" in facts_to_collect and virsh_found["stdout_lines"][0] == "Y"'
-
-- name: gather virt.num_running_guests fact
-  set_fact: virt_num_running_guests="error"
-  when: '"virt.num_running_guests" in facts_to_collect and virsh_found["stdout_lines"][0] == "N"'
+  set_fact: virt_num_running_guests="{{ virt_num_running_guests['stdout_lines'][0] if have_virsh else 'N/A (virsh not found)' }}"
+  when: '"virt.num_running_guests" in facts_to_collect'
 
 - name: add virt.type to dictionary
   set_fact:

--- a/roles/virt_what/tasks/main.yml
+++ b/roles/virt_what/tasks/main.yml
@@ -4,37 +4,31 @@
   set_fact:
     virt_what: "{{ virt_what|default({}) }}"
 
-- name: check if virt-what command exists
-  raw: cmd=$(command -v virt-what>/dev/null); if $cmd; then echo "Y"; else echo "N"; fi
-  register: virt_what_found
-  ignore_errors: yes
-  when: '"virt-what.type" in facts_to_collect'
-
-- name: set virt-what.type fact to error if virt-what not found
-  set_fact: virt_what_type="error"
-  when: '"virt-what.type" in facts_to_collect and virt_what_found["stdout_lines"][0] == "N"'
+- name: set virt-what.type fact if virt-what not found
+  set_fact: virt_what_type='N/A (virt-what not found)'
+  when: '"virt-what.type" in facts_to_collect and not have_virt_what'
 
 - name: execute virt-what
   raw: virt-what;echo $?
   register: virt_what_output
   ignore_errors: yes
   become: yes
-  when: '"virt-what.type" in facts_to_collect and virt_what_found["stdout_lines"][0] == "Y"'
+  when: 'have_virt_what and "virt-what.type" in facts_to_collect'
 
 - name: extract virt-what error code
   set_fact:
     virt_what_error: '{{ virt_what_output["stdout"].split("\r\n")[-1] | int }}'
-  when: '"virt-what.type" in facts_to_collect and virt_what_found["stdout_lines"][0] == "Y"'
+  when: 'have_virt_what and "virt-what.type" in facts_to_collect'
 
 - name: set virt-what.type fact to bare metal if virt-what errored
   set_fact:
     virt_what_type: "bare metal"
-  when: '"virt-what.type" in facts_to_collect and (not virt_what_error|int  == 0)'
+  when: 'have_virt_what and "virt-what.type" in facts_to_collect and (not virt_what_error|int  == 0)'
 
 - name: set virt-what.type fact if virt-what ran successfully
   set_fact:
     virt_what_type: '{{ ";".join(virt_what_output["stdout_lines"][:-1]) }}'
-  when: '"virt-what.type" in facts_to_collect and (virt_what_error|int == 0)'
+  when: 'have_virt_what and "virt-what.type" in facts_to_collect and (virt_what_error|int == 0)'
 
 - name: add virt-what.type to dictionary
   set_fact:


### PR DESCRIPTION
Check whether programs we need (like dmidecode and tune2fs) are
present on the remote machine before running commands that depend on
them. If they aren't present, we give report messages like "N/A
(dmidecode not found)" instead of propagating a shell error message to
the output.

This also adds a file to the documentation listing exactly what
executables are needed for each set of facts. We do not explicitly
check for standard Unix things like grep and sed, so if those are
missing we would still give a shell error, but the documentation lists
all of the programs we need.