### PR TITLE
Support CIDR address ranges

### DIFF
--- a/rho/profileaddcommand.py
+++ b/rho/profileaddcommand.py
@@ -116,7 +116,6 @@ class ProfileAddCommand(CliCommand):
     # pylint: disable=too-many-locals
     def _do_command(self):
         vault = get_vault(self.options.vaultfile)
-        hosts_list = self.options.hosts
         profiles_list = []
         ssh_port = self.options.sshport
 
@@ -127,7 +126,7 @@ class ProfileAddCommand(CliCommand):
                 print(_("Profile '%s' already exists.") % self.options.name)
                 sys.exit(1)
 
-        range_list = read_ranges(hosts_list)
+        range_list = read_ranges(self.options.hosts)
 
         if not os.path.isfile(utilities.CREDENTIALS_PATH):
             print(_('No credentials exist yet.'))

--- a/rho/profileaddcommand.py
+++ b/rho/profileaddcommand.py
@@ -21,7 +21,7 @@ from collections import OrderedDict
 from rho import utilities
 from rho.clicommand import CliCommand
 from rho.vault import get_vault
-from rho.utilities import multi_arg, check_range_validity, _read_in_file
+from rho.utilities import multi_arg, read_ranges
 from rho.translation import _
 
 
@@ -127,12 +127,7 @@ class ProfileAddCommand(CliCommand):
                 print(_("Profile '%s' already exists.") % self.options.name)
                 sys.exit(1)
 
-        range_list = hosts_list
-
-        if hosts_list and os.path.isfile(hosts_list[0]):
-            range_list = _read_in_file(hosts_list[0])
-
-        check_range_validity(range_list)
+        range_list = read_ranges(hosts_list)
 
         if not os.path.isfile(utilities.CREDENTIALS_PATH):
             print(_('No credentials exist yet.'))

--- a/rho/profileeditcommand.py
+++ b/rho/profileeditcommand.py
@@ -20,7 +20,7 @@ import sys
 from rho import utilities
 from rho.clicommand import CliCommand
 from rho.vault import get_vault
-from rho.utilities import multi_arg, check_range_validity, _read_in_file
+from rho.utilities import multi_arg, read_ranges
 from rho.translation import _
 
 
@@ -104,14 +104,7 @@ class ProfileEditCommand(CliCommand):
         profiles_list = vault.load_as_json(utilities.PROFILES_PATH)
 
         if self.options.hosts:
-            hosts_list = self.options.hosts
-            range_list = hosts_list
-            if os.path.isfile(hosts_list[0]):
-                range_list = _read_in_file(hosts_list[0])
-
-            # makes sure the hosts passed in are in a format Ansible
-            # understands.
-            check_range_validity(range_list)
+            range_list = read_ranges(self.options.hosts)
 
         for curr_profile in profiles_list:
             if curr_profile.get('name') == self.options.name:

--- a/rho/utilities.py
+++ b/rho/utilities.py
@@ -12,6 +12,7 @@
 
 from __future__ import print_function
 import csv
+import logging
 import os
 import re
 import sys
@@ -230,10 +231,18 @@ def _read_in_file(filename):
 
 # Makes sure the hosts passed in are in a format Ansible
 # understands.
-def check_range_validity(range_list):
-    """Checks the input range_list to see if it meets the Ansible
-    range criteria
-    :param range_list: list of hosts
+def read_ranges(ranges_or_path):
+    """Process a range list from the user.
+
+    This function reads a hosts file if necessary, validates that all
+    IP ranges are in Ansible format, and rewrites CIDR address ranges
+    to Ansible format if necessary.
+
+    :param ranges_or_path: either a list of IP address ranges or a
+      one-element list where the one element is the path of a file
+      with ranges.
+    :returns: list of IP address ranges in Ansible format
+
     """
     # pylint: disable=anomalous-backslash-in-string
     regex_list = ['[0-9]*.[0-9]*.[0-9]*.\[[0-9]*:[0-9]*\]',
@@ -243,19 +252,120 @@ def check_range_validity(range_list):
                   '[a-zA-Z0-9-\.]*\[[0-9]*:[0-9]*\]*[a-zA-Z0-9-\.]*',
                   '[a-zA-Z0-9-\.]*\[[a-zA-Z]*:[a-zA-Z]*\][a-zA-Z0-9-\.]*']
 
-    for reg_item in range_list:
-        match = False
-        for reg in regex_list:
-            matches = re.findall(reg, reg_item)
-            if len(matches) == 1:
-                match = True
-        if not match:
-            if len(reg_item) <= 1:
-                print(_("No such hosts file."))
+    if ranges_or_path and os.path.isfile(ranges_or_path[0]):
+        range_list = _read_in_file(ranges_or_path[0])
+    else:
+        range_list = ranges_or_path
 
-            print(_("Bad host name/range : '%s'") % reg_item)
+    normalized = []
+
+    for reg_item in range_list:
+        match_found = False
+        for reg in regex_list:
+            match = re.match(reg, reg_item)
+            if match and match.end() == len(reg_item):
+                normalized.append(reg_item)
+                match_found = True
+                break
+
+        if not match_found:
+            try:
+                normalized.append(cidr_to_ansible(reg_item))
+                match_found = True
+            except NotCIDRException:
+                pass
+
+        if not match_found:
+            logging.error(_("Bad host name/range : '%s'"), reg_item)
+            if len(range_list) <= 1:
+                logging.error(_("Couldn't interpret %s as host file because "
+                                "no such file", reg_item))
+
             sys.exit(1)
-    return True
+
+    return normalized
+
+
+class NotCIDRException(Exception):
+    """Exception for when a string does not look like a CIDR range."""
+
+    pass
+
+
+def cidr_to_ansible(ip_range):
+    """Convert an IP address range from CIDR to Ansible notation.
+
+    :param ip_range: the IP range, as a string
+    :returns: the IP range, as an Ansible-formatted string
+
+    Raises NotCIDRException if ip_range doesn't look similar to CIDR
+    notation. If it does look like CIDR but isn't quite right, print
+    out error messages and exit.
+    """
+
+    # In the case of an input error, we want to distinguish between
+    # strings that are "CIDR-like", so the user probably intended to
+    # use CIDR and we should give them a CIDR error message, and not
+    # at all CIDR-like, in which case we tell the caller to parse it a
+    # different way.
+    cidr_like = r'[0-9.]*/[0-9]*'
+
+    if not re.match(cidr_like, ip_range):
+        raise NotCIDRException
+
+    base_address, prefix_bits = ip_range.split('/')
+    prefix_bits = int(prefix_bits)
+
+    if prefix_bits < 0 or prefix_bits > 32:
+        logging.error('Bit mask length %s of IP range %s is not in the valid '
+                      'range [0,32].', prefix_bits, ip_range)
+        sys.exit(1)
+
+    octet_strings = base_address.split('.')
+    if len(octet_strings) != 4:
+        logging.error('IP address %s (part of IP range %s) '
+                      'does not have exactly 4 octets', base_address, ip_range)
+        sys.exit(1)
+
+    octets = [None] * 4
+    for i in range(4):
+        if not octet_strings[i]:
+            logging.error('Empty octet in IP range %s', ip_range)
+            sys.exit(1)
+
+        val = int(octet_strings[i])
+        if val < 0 or val > 255:
+            logging.error('IP octet %s (part of IP range %s) '
+                          'is not in the valid range [0,255]', val, ip_range)
+            sys.exit(1)
+        octets[i] = val
+
+    ansible_out = [None] * 4
+    for i in range(4):
+        # "prefix_bits" is the number of high-order bits we want to
+        # keep for the whole CIDR range. "mask" is the number of
+        # low-order bits we want to mask off. Here prefix_bits is for
+        # the whole IP address, but mask_bits is just for this octet.
+
+        if prefix_bits <= i * 8:
+            ansible_out[i] = '[0:255]'
+        elif prefix_bits >= (i + 1) * 8:
+            ansible_out[i] = str(octets[i])
+        else:
+            # The number of bits of this octet that we want to
+            # preserve
+            this_octet_bits = prefix_bits - 8 * i
+            assert 0 < this_octet_bits < 8
+            # mask is this_octet_bits 1's followed by (8 -
+            # this_octet_bits) 0's.
+            mask = -1 << (8 - this_octet_bits)
+
+            lower_bound = octets[i] & mask
+            upper_bound = lower_bound + ~mask
+            ansible_out[i] = '[{0}:{1}]'.format(
+                lower_bound, upper_bound)
+
+    return '.'.join(ansible_out)
 
 
 def validate_port(arg):

--- a/test/test_utilities.py
+++ b/test/test_utilities.py
@@ -103,7 +103,7 @@ class TestReadRanges(unittest.TestCase):
             ['192.168.124.[0:127]'])
 
 
-class TestCidrToAnsible(unittest.TestCase):
+class TestCIDRToAnsible(unittest.TestCase):
     def test_wrong_format(self):
         with self.assertRaises(utilities.NotCIDRException):
             utilities.cidr_to_ansible('www.redhat.com')

--- a/test/test_utilities.py
+++ b/test/test_utilities.py
@@ -73,30 +73,84 @@ class TestTailing(unittest.TestCase):
             self.assertEqual(follow_list_out.getvalue(), 'follow\n')
 
 
-class TestRangeValidity(unittest.TestCase):
+class TestReadRanges(unittest.TestCase):
 
-    def testcheck_range_validity(self):
-        valid_range_list = ['10.10.181.9',
-                            '10.10.128.[1:25]',
-                            '10.10.[1:20].25',
-                            '10.10.[1:20].[1:25]',
-                            'localhost',
-                            'mycentos.com',
-                            'my-rhel[a:d].company.com',
-                            'my-rhel[120:400].company.com']
-        result = utilities.check_range_validity(valid_range_list)
-        self.assertTrue(result)
+    def test_valid_ranges(self):
+        range_list = ['10.10.181.9',
+                      '10.10.128.[1:25]',
+                      '10.10.[1:20].25',
+                      '10.10.[1:20].[1:25]',
+                      'localhost',
+                      'mycentos.com',
+                      'my-rhel[a:d].company.com',
+                      'my-rhel[120:400].company.com']
+        result = utilities.read_ranges(range_list)
+        self.assertEqual(range_list, result)
 
-    def testcheck_range_validity_error(self):
-        valid_range_list = ['10.10.[181.9',
-                            '10.10.128.[a:25]',
-                            '10.10.[1-20].25',
-                            'my_rhel[a:d].company.com',
-                            'my-rhel[a:400].company.com']
+    def test_invalid_ranges(self):
+        range_list = ['10.10.[181.9',
+                      '10.10.128.[a:25]',
+                      '10.10.[1-20].25',
+                      'my_rhel[a:d].company.com',
+                      'my-rhel[a:400].company.com']
         with self.assertRaises(SystemExit):
-            utilities.check_range_validity(valid_range_list)
+            utilities.read_ranges(range_list)
 
-    def testcheck_range_cidr_error(self):
-        valid_range_list = ['192.168.124.0/25']
+    def test_cidr_range(self):
+        range_list = ['192.168.124.0/25']
+        self.assertEqual(
+            utilities.read_ranges(range_list),
+            ['192.168.124.[0:127]'])
+
+
+class TestCidrToAnsible(unittest.TestCase):
+    def test_wrong_format(self):
+        with self.assertRaises(utilities.NotCIDRException):
+            utilities.cidr_to_ansible('www.redhat.com')
+
+    def test_extra_dots(self):
         with self.assertRaises(SystemExit):
-            utilities.check_range_validity(valid_range_list)
+            utilities.cidr_to_ansible('1.2..3.4/26')
+
+    def test_octet_out_of_range(self):
+        with self.assertRaises(SystemExit):
+            utilities.cidr_to_ansible('1.2.3.256/12')
+
+    def test_prefix_out_of_range(self):
+        with self.assertRaises(SystemExit):
+            utilities.cidr_to_ansible('1.2.3.4/33')
+
+    def test_no_prefix(self):
+        self.assertEqual(
+            utilities.cidr_to_ansible('1.2.3.4/0'),
+            '[0:255].[0:255].[0:255].[0:255]')
+
+    def test_exact_ip(self):
+        self.assertEqual(
+            utilities.cidr_to_ansible('1.2.3.4/32'),
+            '1.2.3.4')
+
+    def test_first_octet(self):
+        self.assertEqual(
+            utilities.cidr_to_ansible('15.2.3.4/6'),
+            '[12:15].[0:255].[0:255].[0:255]')
+
+    def test_last_octet(self):
+        self.assertEqual(
+            utilities.cidr_to_ansible('1.2.3.4/30'),
+            '1.2.3.[4:7]')
+
+    def test_octet_boundary(self):
+        self.assertEqual(
+            utilities.cidr_to_ansible('1.2.3.4/16'),
+            '1.2.[0:255].[0:255]')
+
+    def test_beginning_of_octet(self):
+        self.assertEqual(
+            utilities.cidr_to_ansible('192.168.1.1/17'),
+            '192.168.[0:127].[0:255]')
+
+    def test_end_of_octet(self):
+        self.assertEqual(
+            utilities.cidr_to_ansible('192.168.1.1/23'),
+            '192.168.[0:1].[0:255]')


### PR DESCRIPTION
Support CIDR address ranges by validating them and rewriting them as
Ansible-format address ranges before passing them to Ansible.

Also move some duplicate host-file code into a single function in
utilities.py, and fix an issue where check_range_validity could have
accepted invalid ranges.

Closes #250 , closes #280 