### PR TITLE
Improve docs

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -76,7 +76,7 @@ Adding Facts
 If you want to make a change that affects the documentation of
 particular facts,
 
-1. Make the change in `doc/command_syntax_usage.rst`
+1. Make the change in `doc/source/command_syntax_usage.rst`
 2. Run `make gen-python-docs` to update `rho/fact_docs.py`
 3. Check in the new version of `rho/fact_docs.py` with your change
 

--- a/README.rst
+++ b/README.rst
@@ -3,10 +3,8 @@
 .. image:: https://coveralls.io/repos/github/quipucords/rho/badge.svg
     :target: https://coveralls.io/github/quipucords/rho
 
-
-====================================================================
-   rho - Tool for discovering RHEL, Linux, and Unix Servers
-====================================================================
+rho - Tool for discovering RHEL, Linux, and Unix Servers
+========================================================
 
 rho is a tool for scanning a network, logging into systems using SSH, and
 retrieving information about available Unix and Linux servers.
@@ -26,9 +24,9 @@ command and command options with rho, see the *manpage*.
 - `Contributing`_
 - `Copyright & License`_
 
--------------
 Intro to rho
--------------
+------------
+
 rho is an Ansible-based network inventory tool. rho scans a user-defined range
 of machines and then reports basic information about the operating system and
 hardware for each server. rho simplifies some basic sysadmin tasks, like
@@ -99,9 +97,9 @@ virtual hosts, and virtual guests, and identifies several major virtual types
 and maintaining software licenses to separate virtual hosts from guests; rho
 returns that information with every scan, by default.
 
---------------------------
 Requirements & Assumptions
 --------------------------
+
 Before installing rho, there are some guidelines about which machine it should be installed on:
  * rho is written to run on RHEL or Fedora servers.
  * The machine that rho is installed on must be able to access the machines to be scanned, so it must be on the network and the machines must be running.
@@ -135,9 +133,9 @@ The following python packages are required to build & test rho from source:
  * six
  * docutils
 
--------------
 Installation
--------------
+------------
+
 rho is available for `download <https://copr.fedorainfracloud.org/coprs/chambridge/rho/>`_ from fedora COPR.
 
 1. First, make sure that the EPEL repo is enabled for the server.
@@ -154,9 +152,9 @@ You can find the appropriate architecture and version on the `COPR rho page <htt
 
 ``yum install rho``
 
------------------------
 Command Syntax & Usage
------------------------
+----------------------
+
 The basic syntax is:
 
 ``rho command subcommand [options]``
@@ -183,11 +181,11 @@ rho manpage with other usage examples. The common options are listed with the
 examples in this document.
 
 For expanded information on auth entries, profiles, scanning, and output read
-the `syntax and usage document <doc/command_syntax_usage.rst>`_.
+the `syntax and usage document <doc/source/command_syntax_usage.rst>`_.
 
------------------------
 Development
------------------------
+-----------
+
 Begin by cloning the repository::
 
     git clone git@github.com:quipucords/rho.git
@@ -197,34 +195,32 @@ system follow these `instructions <https://www.python.org/downloads/>`_. Based
 on your system you may be using either `pip` or `pip3` to install modules, for
 simplicity the instructions below will specify `pip`.
 
-^^^^^^^^^^^^^^^^^^^^^^^^
 Installing Dependencies
-^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^
 From within the local clone root directory run the following command to install
 dependencies needed for development and testing purposes::
 
     pip install -r requirements.txt
 
-^^^^^^
 Build
-^^^^^^
+^^^^^
+
 In order to build rho run the following command::
 
     make build
 
-^^^^^^^
 Linting
 ^^^^^^^
+
 In order to lint changes made to the source code execute the following command::
 
     make lint
 
-^^^^^^^^^^^^^^^^^^^^^^^^
 Testing
-^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^
 
 Unit Testing
-""""""""""""""
+""""""""""""
 
 To run the unit tests with the interpreter available as ``python``, use::
 
@@ -235,37 +231,37 @@ Continuous testing runs on travis:
 
 
 Functional Testing
-"""""""""""""""""""
+""""""""""""""""""
 
 To run end-to-end functional tests against local virtual machines follow the
-information in `functional test document <doc/functional_test.rst>`_.
+information in `functional test document <doc/source/functional_test.rst>`_.
 
 
--------------
 Issues
--------------
+------
+
 To report bugs for rho `open issues <https://github.com/quipucords/rho/issues>`_
 against this repository in Github. Please complete the issue template when
 opening a new bug to improve investigation and resolution time.
 
-----------------
 Changes
-----------------
+-------
+
 Track & find changes to the tool in `CHANGES <CHANGES.rst>`_.
 
---------
 Authors
---------
+-------
+
 Authorship and current maintainer information can be found in `AUTHORS <AUTHORS.rst>`_.
 
-----------------
 Contributing
-----------------
+------------
+
 Reference the `CONTRIBUTING <CONTRIBUTING.rst>`_ guide for information to the project.
 
---------------------
 Copyright & License
---------------------
+-------------------
+
 Copyright 2009-2017, Red Hat, Inc.
 
 rho is released under the `GNU Public License version 2 <LICENSE>`_.

--- a/doc/source/command_example.rst
+++ b/doc/source/command_example.rst
@@ -1,6 +1,5 @@
-^^^^^^^^^^^^^^^^^
 Example rho Scan
-^^^^^^^^^^^^^^^^^
+=================
 
 Following is the results of an example rho scan. This is the example of the
 profile called 'big_test' and it's host auth mapping utilizing the cached
@@ -19,7 +18,7 @@ The following files are created but are encrypted using the rho vault password p
 
 
 Example Host Auth Mapping
-""""""""""""""""""""""""""
+-------------------------
 
 ::
 
@@ -56,7 +55,7 @@ Example Host Auth Mapping
 
 
 Facts
-"""""""
+-----
 The facts collected were:
 
 - uname.hostname
@@ -68,7 +67,7 @@ The facts collected were:
 - redhat-packages.num_installed_packages
 
 Example Output
-""""""""""""""""
+--------------
 
 ::
 

--- a/doc/source/command_syntax_usage.rst
+++ b/doc/source/command_syntax_usage.rst
@@ -1,6 +1,6 @@
------------------------
 Command Syntax & Usage
------------------------
+======================
+
 The basic syntax is:
 
 ``rho command subcommand [options]``
@@ -26,9 +26,9 @@ The complete list of options for each command and subcommand are listed in the
 rho manpage with other usage examples. The common options are listed with the
 examples in this document.
 
-^^^^^^^^^^^^^
 Auth Entries
-^^^^^^^^^^^^^
+------------
+
 The first step to configuring rho is adding auth credentials to use to connect
 over SSH. Each authentication identity requires its own auth entry.
 
@@ -36,9 +36,8 @@ over SSH. Each authentication identity requires its own auth entry.
 
 *Note:* --password not being passed or passed as empty are considered the same thing.
 
--------------------------
 SSH Key with a Passphrase
--------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 There are two ways to handle ssh keys with passphrases. If a
 passphrase-protected ssh key is specified in an auth and the key is
@@ -50,9 +49,9 @@ agent (as documented at
 http://docs.ansible.com/ansible/latest/intro_getting_started.html),
 which will decrypt them once and make them available to Rho.
 
-^^^^^^^^^
 Profiles
-^^^^^^^^^
+---------
+
 Then, create the profile to use for the scan. This should include a list of IP
 addresses or ranges, and the auth identity to use.
 
@@ -68,9 +67,9 @@ where ``hosts_file`` contains the ip address or ranges separated by newlines::
   1.2.3.14
   1.2.4.34
 
-^^^^^^^^^
 Scanning
-^^^^^^^^^
+--------
+
 The options required for a scan are the profile to use and the file path for
 the report. Optionally we can pass the number of Ansible forks and the facts to
 be collected. Finally the ``cache`` option tells rho that the profile you are
@@ -100,18 +99,17 @@ The output of the Ansible process is saved to `$XDG_DATA_HOME/rho/scan_log` by
 default, for debugging. This location can be changed with the
 `--logfile` flag.
 
-^^^^^^^^^^^^
 Common Flags
-^^^^^^^^^^^^
+------------
 
 All rho commands accept the `-v` flag, which increases the verbosity
 of rho's output. It comes in four varieties: `-v`, `-vv`, `-vvv`, and
 `-vvvv`, with more `v`'s indicating more verbose output. The verbose
 output can be useful in debugging.
 
-^^^^^^^
 Output
-^^^^^^^
+------
+
 The important part about a scan is the results report. By default,
 this contains a large amount of information about the operating system, hardware, and platform.
 
@@ -186,9 +184,9 @@ of 'default' will get all the information listed above.
 For further details of the command usage view the following
 `example <command_example.rst>`_.
 
-^^^^^^^^^^^^^^^^^^^^^
 Scan User Permissions
-^^^^^^^^^^^^^^^^^^^^^
+---------------------
+
 Some of the output facts will report an error if the user used to perform the
 scan does not have the appropriate permissions to execute the command used to
 gather the targeted facts. The following set of facts require *admin/root*
@@ -218,11 +216,10 @@ If the scan user uses a password to sudo, one can be given with the
 commands. The sudo-with-password fundtionality can be tested by using
 the 'askpass' box in the Vagrantfile.
 
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Programs on Remote Machines
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
+---------------------------
 
 Besides standard Unix utilities, some rho fact collectors depend on
 specific programs being installed on the machines being scanned. The
 complete list is at `remote programs
-<github.com/quipucords/rho/doc/remote_programs.rst>`_.
+<github.com/quipucords/rho/doc/source/remote_programs.rst>`_.

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -98,7 +98,7 @@ html_theme = 'alabaster'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# html_static_path = ['_static']
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.

--- a/doc/source/functional_test.rst
+++ b/doc/source/functional_test.rst
@@ -1,6 +1,5 @@
------------------------
 Functional Testing
------------------------
+==================
 
 The nature of ``rho`` tool is to discover and scan remote systems. In order
 to test this feature locally we need to employ tools to allow us to simulate
@@ -9,14 +8,14 @@ a remote environment. We will be utilizing
 `Virtual Box <https://www.virtualbox.org/wiki/VirtualBox>`_ along with Ansible
 to create and initialize several virtual systems.
 
-^^^^^^^^^^^^^^^^^^^^^^^^
 Installing Dependencies
-^^^^^^^^^^^^^^^^^^^^^^^^
+-----------------------
+
 *Virtual Box*
 
-For OS X you can go to the
-`downloads <https://www.virtualbox.org/wiki/Downloads>`_ page and installation
-using the DMG image.
+For OS X you can go to the `Virtualbox downloads
+<https://www.virtualbox.org/wiki/Downloads>`_ page and installation using the
+DMG image.
 
 For Fedora or RHEL systems:
 Add the `repo file <http://download.virtualbox.org/virtualbox/rpm/fedora/virtualbox.repo>`_
@@ -36,9 +35,9 @@ second tells VirtualBox to build the custom kernel module that it uses.
 
 *Vagrant*
 
-For OS X you can go to the
-`downloads <https://www.vagrantup.com/downloads.html>`_ page and installation
-using the DMG image.
+For OS X you can go to the `Vagrant downloads
+<https://www.vagrantup.com/downloads.html>`_ page and installation using the
+DMG image.
 
 For Fedora or RHEL systems:
 Go to `www.vagrantup.com <www.vagrantup.com>`_, click on "Download", and get
@@ -47,9 +46,8 @@ the Centos 64-bit RPM. Then install with::
   rpm -ivh <package>.rpm
 
 
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Provisioning Virtual Systems
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+----------------------------
 
 From the root directory of the local repository you will see a file named
 `Vagrantfile` which specifies three systems that will be setup and initialized
@@ -59,9 +57,8 @@ directory. Run the following command to provision the systems::
   vagrant up
 
 
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Note: testing on RHEL
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+---------------------
 
 The Vagrantfile assumes the existance of a Vagrant box called
 `rhel-server-7-1`. You can make a RHEL box by following one of the
@@ -72,9 +69,9 @@ https://developers.redhat.com/blog/2016/06/06/using-vagrant-to-get-started-with-
 If you don't want to test with RHEL, you can replace that box name
 with a different one, such as `centos/7`.
 
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Executing rho on Test Bed
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+-------------------------
+
 You should have three virtual systems running with the following IP Address:
 - 192.168.50.10
 - 192.168.50.11

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -10,7 +10,10 @@ Welcome to rho's documentation!
    :maxdepth: 2
    :caption: Contents:
 
-
+   command_syntax_usage
+   command_example
+   remote_programs
+   functional_test
 
 Indices and tables
 ==================

--- a/doc/source/remote_programs.rst
+++ b/doc/source/remote_programs.rst
@@ -1,6 +1,5 @@
----------------
 Remote Programs
----------------
+===============
 
 This file documents which programs on the remote host are used to
 collect different groups of facts. **bold** is used for executables

--- a/rho/authaddcommand.py
+++ b/rho/authaddcommand.py
@@ -26,7 +26,8 @@ from rho.translation import _
 
 
 def auth_exists(cred_list, auth_name):
-    """ Checks whether authentication credential already exists
+    """Checks whether authentication credential already exists
+
     :param cred_list: A list of credential dictionaries
     :param auth_name: Name of credential to check for existence
     :returns: True if auth_name exists, False otherwise
@@ -41,10 +42,11 @@ def auth_exists(cred_list, auth_name):
 
 def _save_cred(vault, new_cred, cred_list):
     """ Write new credentials in the related file
+
     :param vault: Vault object for writing encrypted data
     :param new_cred: New credential to be added to the credentials file
     :param cred_list: A list of existing credential dictionaries from the
-    credential file
+        credential file
     """
 
     utilities.ensure_config_dir_exists()
@@ -84,9 +86,8 @@ def make_auth_for_options(options):
 
 class AuthAddCommand(CliCommand):
     """
-    This command is for creating new auths
-    which can be later associated with profiles
-    to gather facts.
+    This command is for creating new auths which can be later associated with
+    profiles to gather facts.
     """
 
     def __init__(self):

--- a/rho/autheditcommand.py
+++ b/rho/autheditcommand.py
@@ -10,7 +10,7 @@
 
 # pylint: disable=too-few-public-methods
 
-""" AuthEditCommand is used to edit existing authentication credentials
+"""AuthEditCommand is used to edit existing authentication credentials
 for system access
 """
 
@@ -25,14 +25,15 @@ from rho.translation import _
 
 
 def optional_arg(arg_default):
-    """Call back function for arg-parse
-    for when arguments are optional
+    """Call back function for arg-parse for when arguments are optional
+
     :param arg_default: The default for the argument
     :returns: Function for handling the argument
     """
     # pylint: disable=unused-argument
     def func(option, opt_str, value, parser):
         """Function for handling CLI option
+
         :param option: The option
         :param opt_str: The option string
         :param value: The value

--- a/rho/profileaddcommand.py
+++ b/rho/profileaddcommand.py
@@ -27,6 +27,7 @@ from rho.translation import _
 
 def profile_exists(profile_list, profile_name):
     """ Checks whether a network profile already exists
+
     :param profile_list: A list of profile dictionaries
     :param profile_name: Name of a network profile to check for existence
     :returns: True if profile_name exists, False otherwise
@@ -41,10 +42,11 @@ def profile_exists(profile_list, profile_name):
 
 def _save_profile(vault, new_profile, profiles_list):
     """ Write new profile in the related file
+
     :param vault: Vault object for writing encrypted data
     :param new_profile: New profile to be added to the profiles file
     :param profiles_list: A list of existing profiles dictionaries from the
-    profiles file
+        profiles file
     """
 
     utilities.ensure_config_dir_exists()

--- a/rho/scancommand.py
+++ b/rho/scancommand.py
@@ -91,10 +91,11 @@ def redacted_auth_string(auth):
 
 
 def redact_dict(redact_key_list, a_dict):
-    """redact_values in a dictionary
+    """Redact_values in a dictionary
+
     :param redact_key_list: keys in dictionary that value should be redacted
     :param a_dict: A dictionary to redact
-    :return dictionary
+    :returns: the redacted dictionary
     """
     for key in redact_key_list:
         if a_dict is not None and key in a_dict:
@@ -129,8 +130,8 @@ def process_ping_output(out_lines):
     hosts, then sending the output to this function.
 
     :param out_lines: an iterator returning lines of Ansible output.
-    :returns: the hosts that pinged successfully, as a set and those
-    that failed, as a set.
+    :returns: the hosts that pinged successfully, as a set and those that
+        failed, as a set.
     """
 
     success_hosts = set()
@@ -276,12 +277,18 @@ def make_inventory_dict(success_hosts, success_port_map, auth_map):
     :param success_port_map: mapping from hosts to SSH ports
     :param auth_map: map from host IP to a list of auths it works with
 
-    :returns: a dict with the structure
-    {'alpha':
-      {'hosts'
-        {'IP address 1': {host-vars-1},
-         'IP address 2': {host-vars-2},
-         ...}}}
+    :returns: a dict with the structure:
+
+        .. code-block:: python
+
+            {'alpha':
+                {'hosts':
+                    {'IP address 1': {'host-vars-1'},
+                     'IP address 2': {'host-vars-2'},
+                     # ...
+                    }
+                }
+            }
     """
 
     yml_dict = {}

--- a/rho/utilities.py
+++ b/rho/utilities.py
@@ -151,8 +151,8 @@ def setup_logging(verbosity):
 
     Must be run after ensure_data_dir_exists().
 
-    :param verbosity: verbosity level, as measured in -v's on the
-    command line. Can be None for default.
+    :param verbosity: verbosity level, as measured in -v's on the command line.
+        Can be None for default.
     """
 
     if verbosity is None:
@@ -177,6 +177,7 @@ def setup_logging(verbosity):
 
 def threaded_tailing(path, ansible_verbosity=0):
     """Follow and provide output using a thread
+
     :param path: path to file to follow
     :param ansible_verbosity: the verbosity level
     """
@@ -188,6 +189,7 @@ def threaded_tailing(path, ansible_verbosity=0):
 
 def tail_and_follow(path, ansible_verbosity):
     """Follow and provide output
+
     :param path: tuple containing thepath to file to follow
     :param ansible_verbosity: the verbosity level
     """
@@ -235,8 +237,8 @@ def ensure_data_dir_exists():
 
 # pylint: disable=unused-argument
 def multi_arg(option, opt_str, value, parser):
-    """Call back function for arg-parse
-    for when arguments are multiple
+    """Call back function for arg-parse for when arguments are multiple
+
     :param option: The option
     :param opt_str: The option string
     :param value: The value
@@ -277,9 +279,8 @@ def read_ranges(ranges_or_path):
     IP ranges are in Ansible format, and rewrites CIDR address ranges
     to Ansible format if necessary.
 
-    :param ranges_or_path: either a list of IP address ranges or a
-      one-element list where the one element is the path of a file
-      with ranges.
+    :param ranges_or_path: either a list of IP address ranges or a one-element
+        list where the one element is the path of a file with ranges.
     :returns: list of IP address ranges in Ansible format
 
     """
@@ -336,10 +337,9 @@ def cidr_to_ansible(ip_range):
 
     :param ip_range: the IP range, as a string
     :returns: the IP range, as an Ansible-formatted string
-
-    Raises NotCIDRException if ip_range doesn't look similar to CIDR
-    notation. If it does look like CIDR but isn't quite right, print
-    out error messages and exit.
+    :raises NotCIDRException: if ip_range doesn't look similar to CIDR
+        notation. If it does look like CIDR but isn't quite right, print out
+        error messages and exit.
     """
 
     # In the case of an input error, we want to distinguish between
@@ -438,6 +438,7 @@ def validate_port(arg):
 
 def str_to_ascii(in_string):
     """ Coverts unicode string to ascii string
+
     :param in_string: input string to convert to ascii
     :returns: ASCII encoded string
     """
@@ -460,8 +461,9 @@ def iteritems(dictionary):
 
 
 def write_csv_data(keys, data, path):
-    """ Write csv data with input fieldnames a dictionary of data and
-    the file path to write to.
+    """ Write csv data with input fieldnames a dictionary of data and the file
+    path to write to.
+
     :param keys: The field names and keys of the dictionary
     :param data: The dictionary of data to convert to csv
     :param path: The file path to write to
@@ -482,17 +484,18 @@ def write_csv_data(keys, data, path):
 
 
 def get_config_path(filename):
-    """ Provides the path for a configuration filename
+    """Provides the path for a configuration filename
+
     :param filename: The filename to return the config path for
-    :returns path to for filename in XDG_CONFIG_HOME associated with rho
+    :returns: path to for filename in XDG_CONFIG_HOME associated with rho
     """
     return os.path.join(xdg_config_home, RHO_PATH, filename)
 
 
 def check_path_validity(path_list):
-    """ Given a list of paths it verifies that all paths are valid
-    absolute path inputs for a scoped scan. If not it return a list of
-    invalid paths.
+    """Given a list of paths it verifies that all paths are valid absolute
+    path inputs for a scoped scan. If not it return a list of invalid paths.
+
     :param path_list: list of paths to validate
     :return: empty list or list of invalid paths
     """

--- a/rho/vault.py
+++ b/rho/vault.py
@@ -34,7 +34,8 @@ yaml.add_representer(type(None), represent_none)
 
 
 def read_vault_password(vault_password_file):
-    """ Reads vault password from file for scripting
+    """Reads vault password from file for scripting
+
     :param vault_password_file: Path to vault password file
     :returns: vault password string
     """
@@ -50,13 +51,14 @@ def read_vault_password(vault_password_file):
 
 
 def get_vault_password(prompt=PROMPT):
-    """ Requests the users password from the command line """
+    """Requests the users password from the command line """
     return getpass("\033[01;36m" + prompt + "\033[0m")
 
 
 def get_vault_and_password(vaultfile=None, prompt=PROMPT):
-    """ Helper method that will get the vault password via input file or from
+    """Helper method that will get the vault password via input file or from
     standard input and then initialize a vault for users
+
     :param vaultfile: The location of a file with the vault password
     :returns: An initialized vault and the password
     """
@@ -69,8 +71,9 @@ def get_vault_and_password(vaultfile=None, prompt=PROMPT):
 
 
 def get_vault(vaultfile=None, prompt=PROMPT):
-    """ Helper method that will get the vault password via input file or from
+    """Helper method that will get the vault password via input file or from
     standard input and then initialize a vault for users
+
     :param vaultfile: The location of a file with the vault password
     :returns: An initialized vault
     """
@@ -88,6 +91,7 @@ class Vault(object):
 
     def load(self, stream):
         """ Read vault steam and return python object
+
         :param stream: The stream to read data from
         :returns: The decrypted data
         """
@@ -99,6 +103,7 @@ class Vault(object):
 
     def load_secure_file(self, secure_file):
         """ Read vault secured file and return python object
+
         :param secure_file: The file to read data from
         :returns: The decrpted data
         """
@@ -106,6 +111,7 @@ class Vault(object):
 
     def load_as_json(self, secure_file):
         """ Read vault secured file and return json decoded object
+
         :param secure_file: The file to read data from as json
         :returns: The JSON data
         """
@@ -113,6 +119,7 @@ class Vault(object):
 
     def dump(self, data, stream=None):
         """ Encrypt data and print stdout or write to stream
+
         :param data: The information to be encrypted
         :param stream: If not None the location to write the encrypted data to.
         :returns: If stream is None then the encrypted bytes otherwise None.
@@ -125,9 +132,10 @@ class Vault(object):
 
     def dump_as_json(self, obj, stream=None):
         """ Convert object to json and encrypt the data.
+
         :param obj: Python object to convert to json
         :param stream: If not None the location to write the encrypted data to.
-          If this is a file in Python 3, it must be open in binary mode.
+            If this is a file in Python 3, it must be open in binary mode.
         :returns: If stream is None then the encrypted bytes otherwise None.
         """
         data = json.dumps(obj, separators=(',', ': '))
@@ -135,6 +143,7 @@ class Vault(object):
 
     def dump_as_json_to_file(self, obj, file_path):
         """ Convert object to json and encrypt the data.
+
         :param obj: Python object to convert to json
         :param file_path: The file to write data to via temp file
         """
@@ -145,6 +154,7 @@ class Vault(object):
 
     def dump_as_yaml(self, obj, stream=None):
         """ Convert object to yaml and encrypt the data.
+
         :param obj: Python object to convert to yaml
         :param stream: If not None the location to write the encrypted data to.
         :returns: If stream is None then the encrypted bytes otherwise None.
@@ -154,6 +164,7 @@ class Vault(object):
 
     def dump_as_yaml_to_file(self, obj, file_path):
         """ Convert object to yaml and encrypt the data.
+
         :param obj: Python object to convert to yaml
         :param file_path: The file to write data to via temp file
         """


### PR DESCRIPTION
* Move all document source into the doc/source directory.
* Fix RST markup on some methods and funtions.
* Normalize sections to follow conventions used in Python’s Style Guide
  for documenting (http://www.sphinx-doc.org/en/stable/rest.html#sections).