### PR TITLE
Check for common JBoss directories

### DIFF
--- a/doc/source/command_syntax_usage.rst
+++ b/doc/source/command_syntax_usage.rst
@@ -141,6 +141,7 @@ this contains a large amount of information about the operating system, hardware
 - ``jboss.brms.drools-core-ver`` - Drools version
 - ``jboss.brms.kie-api-ver`` - KIE API version
 - ``jboss.brms.kie-war-ver`` - KIE runtime version
+- ``jboss.eap.common-directories`` - Presence of common directories for JBoss
 - ``jboss.eap.deploy-dates`` - List of deployment dates of JBoss installations
 - ``jboss.eap.installed-versions`` - List of installed versions of JBoss
 - ``jboss.eap.jboss-user`` - Whether a user called 'jboss' exists

--- a/doc/source/command_syntax_usage.rst
+++ b/doc/source/command_syntax_usage.rst
@@ -141,11 +141,11 @@ this contains a large amount of information about the operating system, hardware
 - ``jboss.brms.drools-core-ver`` - Drools version
 - ``jboss.brms.kie-api-ver`` - KIE API version
 - ``jboss.brms.kie-war-ver`` - KIE runtime version
-- ``jboss.eap.common-directories`` - Presence of common directories for JBoss
-- ``jboss.eap.deploy-dates`` - List of deployment dates of JBoss installations
-- ``jboss.eap.installed-versions`` - List of installed versions of JBoss
+- ``jboss.eap.common-directories`` - Presence of common directories for JBoss EAP
+- ``jboss.eap.deploy-dates`` - List of deployment dates of JBoss EAP installations
+- ``jboss.eap.installed-versions`` - List of installed versions of JBoss EAP
 - ``jboss.eap.jboss-user`` - Whether a user called 'jboss' exists
-- ``jboss.eap.running-versions`` - List of running versions of JBoss
+- ``jboss.eap.running-versions`` - List of running versions of JBoss EAP
 - ``jboss.fuse.activemq-ver`` - ActiveMQ version
 - ``jboss.fuse.camel-ver`` - Camel version
 - ``jboss.fuse.cxf-ver`` - CXF version

--- a/doc/source/remote_programs.rst
+++ b/doc/source/remote_programs.rst
@@ -52,6 +52,7 @@ like those provided by bash.
   - ls
   - sort
   - id
+  - test
 - redhat_packages
   - **rpm**
 - redhat_release.*

--- a/library/spit_results.py
+++ b/library/spit_results.py
@@ -331,7 +331,7 @@ def process_id_u_jboss(fact_names, host_vars):
 JBOSS_EAP_COMMON_DIRECTORIES = 'jboss.eap.common-directories'
 
 
-def process_jboss_common_dirs(fact_names, host_vars):
+def process_jboss_eap_common_dirs(fact_names, host_vars):
     """Process the output of 'test -d <dir>', for common install directories.
 
     :returns: a dict of key, value pairs to add to the output.
@@ -555,7 +555,7 @@ class Results(object):
             host_vals.update(process_jboss_versions(keys, host_vars))
             host_vals.update(process_addon_versions(keys, host_vars))
             host_vals.update(process_id_u_jboss(keys, host_vars))
-            host_vals.update(process_jboss_common_dirs(keys, host_vars))
+            host_vals.update(process_jboss_eap_common_dirs(keys, host_vars))
 
         # Process System ID.
         for data in self.vals:

--- a/rho/utilities.py
+++ b/rho/utilities.py
@@ -114,7 +114,8 @@ SUBMAN_FACTS_TUPLE = ('subman.cpu.core(s)_per_socket',
                       'subman.has_facts_file')
 
 JBOSS_FACTS_TUPLE = ('jboss.eap.running-versions',
-                     'jboss.eap.jboss-user')
+                     'jboss.eap.jboss-user',
+                     'jboss.eap.common-directories')
 
 JBOSS_SCAN_FACTS_TUPLE = ('jboss.eap.installed-versions',
                           'jboss.eap.deploy-dates')

--- a/roles/jboss_eap/tasks/main.yml
+++ b/roles/jboss_eap/tasks/main.yml
@@ -9,3 +9,12 @@
       raw: id -u jboss
       register: jboss_eap_id_jboss
       ignore_errors: yes
+      when: '"jboss.eap.jboss-user" in facts_to_collect'
+    - name: check for common install directories
+      raw: test -d "{{ item }}"
+      register: jboss_eap_common_directories
+      ignore_errors: yes
+      with_items:
+        - /var/log/jboss-as
+        - /usr/log/jboss-as
+      when: '"jboss.eap.common-directories" in facts_to_collect'

--- a/test/test_spit_results.py
+++ b/test/test_spit_results.py
@@ -131,3 +131,39 @@ class TestProcessIdUJboss(unittest.TestCase):
         self.assertTrue('jboss.eap.jboss-user' in res and
                         res['jboss.eap.jboss-user'].startswith('Error:'),
                         msg=res['jboss.eap.jboss-user'])
+
+
+class TestProcessJbossCommonDirectories(unittest.TestCase):
+    def run_func(self, output):
+        return spit_results.process_jboss_common_dirs(
+            ['jboss.eap.common-directories'],
+            {'jboss_eap_common_directories': output})
+
+    def test_fact_not_requested(self):
+        self.assertEqual(
+            spit_results.process_jboss_common_dirs([], {}),
+            {})
+
+    def test_not_in_host_vars(self):
+        res = spit_results.process_jboss_common_dirs(
+            ['jboss.eap.common-directories'], {})
+
+        self.assertTrue(
+            'jboss.eap.common-directories' in res and
+            res['jboss.eap.common-directories'].startswith('Error:'),
+            msg=res['jboss.eap.common-directories'])
+
+    def test_three_states(self):
+        self.assertEqual(
+            self.run_func({
+                'results': [
+                    {'item': 'dir1',
+                     'skipped': True},
+                    {'item': 'dir2',
+                     'rc': 1},
+                    {'item': 'dir3',
+                     'rc': 0}]}),
+            {'jboss.eap.common-directories':
+             'Error: "test -d dir1" not run;'
+             'dir2 not found;'
+             'dir3 found'})

--- a/test/test_spit_results.py
+++ b/test/test_spit_results.py
@@ -135,17 +135,17 @@ class TestProcessIdUJboss(unittest.TestCase):
 
 class TestProcessJbossCommonDirectories(unittest.TestCase):
     def run_func(self, output):
-        return spit_results.process_jboss_common_dirs(
+        return spit_results.process_jboss_eap_common_dirs(
             ['jboss.eap.common-directories'],
             {'jboss_eap_common_directories': output})
 
     def test_fact_not_requested(self):
         self.assertEqual(
-            spit_results.process_jboss_common_dirs([], {}),
+            spit_results.process_jboss_eap_common_dirs([], {}),
             {})
 
     def test_not_in_host_vars(self):
-        res = spit_results.process_jboss_common_dirs(
+        res = spit_results.process_jboss_eap_common_dirs(
             ['jboss.eap.common-directories'], {})
 
         self.assertTrue(


### PR DESCRIPTION
This includes all of the code needed to check for the presence of
directories that would indicate a JBoss installation. The list of
directories here is not comprehensive; that will be a separate change.