### PR TITLE
Check for 'eap' processes in JBoss scan

### DIFF
--- a/doc/source/remote_programs.rst
+++ b/doc/source/remote_programs.rst
@@ -53,6 +53,7 @@ like those provided by bash.
   - sort
   - id
   - test
+  - ps
 - redhat_packages
   - **rpm**
 - redhat_release.*

--- a/rho/utilities.py
+++ b/rho/utilities.py
@@ -115,7 +115,8 @@ SUBMAN_FACTS_TUPLE = ('subman.cpu.core(s)_per_socket',
 
 JBOSS_FACTS_TUPLE = ('jboss.eap.running-versions',
                      'jboss.eap.jboss-user',
-                     'jboss.eap.common-directories')
+                     'jboss.eap.common-directories',
+                     'jboss.eap.processes')
 
 JBOSS_SCAN_FACTS_TUPLE = ('jboss.eap.installed-versions',
                           'jboss.eap.deploy-dates')

--- a/roles/jboss_eap/tasks/main.yml
+++ b/roles/jboss_eap/tasks/main.yml
@@ -18,3 +18,8 @@
         - /var/log/jboss-as
         - /usr/log/jboss-as
       when: '"jboss.eap.common-directories" in facts_to_collect'
+    - name: gather jboss.eap.processes
+      raw: pgrep -f eap
+      register: jboss.eap.processes
+      ignore_errors: yes
+      when: '"jboss.eap.processes" in facts_to_collect'

--- a/roles/jboss_eap/tasks/main.yml
+++ b/roles/jboss_eap/tasks/main.yml
@@ -19,7 +19,7 @@
         - /usr/log/jboss-as
       when: '"jboss.eap.common-directories" in facts_to_collect'
     - name: gather jboss.eap.processes
-      raw: pgrep -f eap
+      raw: ps -A -f | grep eap
       register: jboss.eap.processes
       ignore_errors: yes
       when: '"jboss.eap.processes" in facts_to_collect'

--- a/test/test_spit_results.py
+++ b/test/test_spit_results.py
@@ -115,7 +115,7 @@ class TestProcessIdUJboss(unittest.TestCase):
 
     def test_user_found(self):
         self.assertEqual(
-            self.run_func({'rc': 0}),
+            self.run_func({'rc': 0, 'stdout_lines': []}),
             {'jboss.eap.jboss-user': "User 'jboss' present"})
 
     def test_no_such_user(self):
@@ -167,3 +167,20 @@ class TestProcessJbossCommonDirectories(unittest.TestCase):
              'Error: "test -d dir1" not run;'
              'dir2 not found;'
              'dir3 found'})
+
+
+class TestProcessJbossEapProcesses(unittest.TestCase):
+    def run_func(self, output):
+        return spit_results.process_jboss_eap_processes(
+            ['jboss.eap.processes'],
+            {'jboss.eap.processes': output})
+
+    def test_no_processes(self):
+        self.assertEqual(self.run_func({
+            'rc': 1, 'stdout_lines': []}),
+                         {'jboss.eap.processes': 'No EAP processes found'})
+
+    def test_found_processes(self):
+        self.assertEqual(self.run_func({
+            'rc': 0, 'stdout_lines': [1,2,3]}),
+                         {'jboss.eap.processes': '3 EAP processes found'})

--- a/test/test_spit_results.py
+++ b/test/test_spit_results.py
@@ -183,4 +183,4 @@ class TestProcessJbossEapProcesses(unittest.TestCase):
     def test_found_processes(self):
         self.assertEqual(
             self.run_func({'rc': 0, 'stdout_lines': [1, 2, 3]}),
-            {'jboss.eap.processes': '3 EAP processes found'})
+            {'jboss.eap.processes': '2 EAP processes found'})

--- a/test/test_spit_results.py
+++ b/test/test_spit_results.py
@@ -176,11 +176,11 @@ class TestProcessJbossEapProcesses(unittest.TestCase):
             {'jboss.eap.processes': output})
 
     def test_no_processes(self):
-        self.assertEqual(self.run_func({
-            'rc': 1, 'stdout_lines': []}),
-                         {'jboss.eap.processes': 'No EAP processes found'})
+        self.assertEqual(
+            self.run_func({'rc': 1, 'stdout_lines': []}),
+            {'jboss.eap.processes': 'No EAP processes found'})
 
     def test_found_processes(self):
-        self.assertEqual(self.run_func({
-            'rc': 0, 'stdout_lines': [1,2,3]}),
-                         {'jboss.eap.processes': '3 EAP processes found'})
+        self.assertEqual(
+            self.run_func({'rc': 0, 'stdout_lines': [1, 2, 3]}),
+            {'jboss.eap.processes': '3 EAP processes found'})


### PR DESCRIPTION
See whether any processes on the system have 'eap' in their process
name or arguments. This will help detect JBoss EAP installations.

In addition, consolidate some duplicate functionality into a single function.

Closes #339 .