### PR TITLE
Look for RPM packages whose names look like JBoss packages

### DIFF
--- a/doc/source/command_syntax_usage.rst
+++ b/doc/source/command_syntax_usage.rst
@@ -145,6 +145,8 @@ this contains a large amount of information about the operating system, hardware
 - ``jboss.eap.deploy-dates`` - List of deployment dates of JBoss EAP installations
 - ``jboss.eap.installed-versions`` - List of installed versions of JBoss EAP
 - ``jboss.eap.jboss-user`` - Whether a user called 'jboss' exists
+- ``jboss.eap.packages`` - Installed RPMs that look like JBoss
+- ``jboss.eap.processes`` - Running processes that look like JBoss
 - ``jboss.eap.running-versions`` - List of running versions of JBoss EAP
 - ``jboss.fuse.activemq-ver`` - ActiveMQ version
 - ``jboss.fuse.camel-ver`` - Camel version

--- a/doc/source/remote_programs.rst
+++ b/doc/source/remote_programs.rst
@@ -54,6 +54,7 @@ like those provided by bash.
   - id
   - test
   - ps
+  - **rpm**
 - redhat_packages
   - **rpm**
 - redhat_release.*

--- a/rho/utilities.py
+++ b/rho/utilities.py
@@ -116,7 +116,8 @@ SUBMAN_FACTS_TUPLE = ('subman.cpu.core(s)_per_socket',
 JBOSS_FACTS_TUPLE = ('jboss.eap.running-versions',
                      'jboss.eap.jboss-user',
                      'jboss.eap.common-directories',
-                     'jboss.eap.processes')
+                     'jboss.eap.processes',
+                     'jboss.eap.packages')
 
 JBOSS_SCAN_FACTS_TUPLE = ('jboss.eap.installed-versions',
                           'jboss.eap.deploy-dates')

--- a/roles/jboss_eap/tasks/main.yml
+++ b/roles/jboss_eap/tasks/main.yml
@@ -23,3 +23,8 @@
       register: jboss.eap.processes
       ignore_errors: yes
       when: '"jboss.eap.processes" in facts_to_collect'
+    - name: check for jboss packages
+      raw: rpm -qa --qf "%{NAME}|%{VERSION}|%{RELEASE}|%{INSTALLTIME}|%{VENDOR}|%{BUILDTIME}|%{BUILDHOST}|%{SOURCERPM}|%{LICENSE}|%{PACKAGER}|%{INSTALLTIME:date}|%{BUILDTIME:date}\n" | grep -E '(eap7)|(jbossas)' | sort
+      register: jboss.eap.packages
+      ignore_errors: yes
+      when: '"jboss.eap.packages" in facts_to_collect'

--- a/test/test_spit_results.py
+++ b/test/test_spit_results.py
@@ -184,3 +184,25 @@ class TestProcessJbossEapProcesses(unittest.TestCase):
         self.assertEqual(
             self.run_func({'rc': 0, 'stdout_lines': [1, 2, 3]}),
             {'jboss.eap.processes': '2 EAP processes found'})
+
+
+class TestProcessJbossEapPackages(unittest.TestCase):
+    def run_func(self, output):
+        return spit_results.process_jboss_eap_packages(
+            ['jboss.eap.packages'],
+            {'jboss.eap.packages': output})
+
+    def test_nonzero_return_code(self):
+        self.assertEqual(
+            self.run_func({'rc': 1, 'stdout_lines': []}),
+            {'jboss.eap.packages': 'Pipeline returned non-zero status'})
+
+    def test_found_packages(self):
+        self.assertEqual(
+            self.run_func({'rc': 0, 'stdout_lines': ['a', 'b', 'c']}),
+            {'jboss.eap.packages': '3 JBoss-related packages found'})
+
+    def test_no_packages(self):
+        self.assertEqual(
+            self.run_func({'rc': 0, 'stdout_lines': []}),
+            {'jboss.eap.packages': '0 JBoss-related packages found'})


### PR DESCRIPTION
Yet another lightweight way to check for JBoss installations.

Closes #341 .