### PR TITLE
Check for eap in the environment of running processes

### DIFF
--- a/roles/jboss_eap/tasks/main.yml
+++ b/roles/jboss_eap/tasks/main.yml
@@ -19,7 +19,7 @@
         - /usr/log/jboss-as
       when: '"jboss.eap.common-directories" in facts_to_collect'
     - name: gather jboss.eap.processes
-      raw: ps -A -f | grep eap
+      raw: ps -A -f e | grep eap
       register: jboss.eap.processes
       ignore_errors: yes
       when: '"jboss.eap.processes" in facts_to_collect'

--- a/test/test_spit_results.py
+++ b/test/test_spit_results.py
@@ -183,7 +183,7 @@ class TestProcessJbossEapProcesses(unittest.TestCase):
     def test_found_processes(self):
         self.assertEqual(
             self.run_func({'rc': 0, 'stdout_lines': [1, 2, 3]}),
-            {'jboss.eap.processes': '2 EAP processes found'})
+            {'jboss.eap.processes': '1 EAP processes found'})
 
 
 class TestProcessJbossEapPackages(unittest.TestCase):


### PR DESCRIPTION
That matches several environment variables that I have observed in a
running jboss process.

Also includes a bug fix that removes a false positive process in the
process scan.

Closes #340 .