### PR TITLE
Add some more common EAP install directories

### DIFF
--- a/roles/jboss_eap/tasks/main.yml
+++ b/roles/jboss_eap/tasks/main.yml
@@ -17,6 +17,10 @@
       with_items:
         - /var/log/jboss-as
         - /usr/log/jboss-as
+        - /opt/rh/eap7
+        - /home/jboss/EAP
+        - /home/jboss/EAP-6.3
+        - /usr/share/jbossas
       when: '"jboss.eap.common-directories" in facts_to_collect'
     - name: gather jboss.eap.processes
       raw: ps -A -f e | grep eap


### PR DESCRIPTION
This covers EAP versions 6 and 7. (I researched EAP 5 too, but I don't have any known install directories for it.)

Closes #349 .