### PR TITLE
Replace safe_ansible_property with raw_output_present

### DIFF
--- a/test/test_spit_results.py
+++ b/test/test_spit_results.py
@@ -67,35 +67,6 @@ class TestSpitResults(unittest.TestCase):
                ansible_mod_cls.call_args)
 
 
-class TestSafeAnsibleProperty(unittest.TestCase):
-    def test_missing_fact(self):
-        self.assertEqual(
-            spit_results.safe_ansible_property(
-                {'foo': 'bar'}, 'baz', 'property'),
-            'error (fact not found)')
-
-    def test_skipped_fact(self):
-        self.assertEqual(
-            spit_results.safe_ansible_property(
-                {'foo': {'skipped': True}}, 'foo', 'property'),
-            'error (fact was skipped)')
-
-    def test_not_skipped_fact(self):
-        fact = {'skipped': False,
-                'property': 'value'}
-        self.assertEqual(
-            spit_results.safe_ansible_property(
-                {'foo': fact}, 'foo', 'property'),
-            'value')
-
-    def test_skipped_not_present(self):
-        fact = {'property': 'value'}
-        self.assertEqual(
-            spit_results.safe_ansible_property(
-                {'foo': fact}, 'foo', 'property'),
-            'value')
-
-
 class TestProcessIdUJboss(unittest.TestCase):
     def run_func(self, output):
         return spit_results.process_id_u_jboss(


### PR DESCRIPTION
Issue #411 revealed that the old error detection process based around
safe_ansible_property had some fundamental holes. Since we already
have a new error detection method based on raw_output_present that
didn't have the same issues, I ported the remaining uses of
safe_ansible_property to the new method and removed
safe_ansible_property.

Closes #411 .