### PR TITLE
Use 'locate' command to find jboss-modules.jar

### DIFF
--- a/doc/facts.rst
+++ b/doc/facts.rst
@@ -30,6 +30,7 @@
 - ``jboss.eap.common-files`` - Presence of common files and directories for JBoss EAP
 - ``jboss.eap.deploy-dates`` - List of deployment dates of JBoss EAP installations
 - ``jboss.eap.installed-versions`` - List of installed versions of JBoss EAP
+- ``jboss.eap.locate-jboss-modules-jar`` - Use locate to find jboss-modules.jar
 - ``jboss.eap.jboss-user`` - Whether a user called 'jboss' exists
 - ``jboss.eap.packages`` - Installed RPMs that look like JBoss
 - ``jboss.eap.processes`` - Running processes that look like JBoss

--- a/library/spit_results.py
+++ b/library/spit_results.py
@@ -491,6 +491,35 @@ def process_jboss_eap_packages(fact_names, host_vars):
             '{0} JBoss-related packages found'.format(num_packages)}
 
 
+JBOSS_EAP_LOCATE_JBOSS_MODULES_JAR = 'jboss.eap.locate-jboss-modules-jar'
+
+
+def process_jboss_eap_locate(fact_names, host_vars):
+    """Process the results of 'locate jboss-modules.jar'.
+
+    :returns: a dict of key, value pairs to add to the output.
+    """
+
+    err, output = raw_output_present(fact_names, host_vars,
+                                     JBOSS_EAP_LOCATE_JBOSS_MODULES_JAR,
+                                     'jboss_eap_locate_jboss_modules_jar',
+                                     'locate jboss-modules.jar')
+    if err is not None:
+        return err
+
+    if not output['rc'] and output['stdout_lines']:
+        return {JBOSS_EAP_LOCATE_JBOSS_MODULES_JAR:
+                ';'.join(output['stdout_lines'])}
+
+    if output['rc'] and not output['stdout_lines']:
+        return {JBOSS_EAP_LOCATE_JBOSS_MODULES_JAR:
+                'jboss-modules.jar not found'}
+
+    return {JBOSS_EAP_LOCATE_JBOSS_MODULES_JAR:
+            "Error code {0} running 'locate jboss-modules.jar': {1}".format(
+                output['rc'], output['stdout'])}
+
+
 def escape_characters(data):
     """ Processes input data values and strips out any newlines or commas
     """
@@ -745,6 +774,7 @@ class Results(object):
             host_vals.update(process_jboss_eap_common_files(keys, host_vars))
             host_vals.update(process_jboss_eap_processes(keys, host_vars))
             host_vals.update(process_jboss_eap_packages(keys, host_vars))
+            host_vals.update(process_jboss_eap_locate(keys, host_vars))
 
         # Process System ID.
         for data in self.vals:

--- a/rho/facts.py
+++ b/rho/facts.py
@@ -170,7 +170,7 @@ new_fact('jboss.eap.installed-versions',
          is_default=False)
 new_fact('jboss.eap.locate-jboss-modules-jar',
          'Use locate to find jboss-modules.jar',
-         is_default=True)
+         is_default=True, categories=[JBOSS_FACTS])
 new_fact('jboss.eap.jboss-user', "Whether a user called 'jboss' exists",
          is_default=True, categories=[JBOSS_FACTS])
 new_fact('jboss.eap.packages', 'Installed RPMs that look like JBoss',

--- a/rho/facts.py
+++ b/rho/facts.py
@@ -168,6 +168,9 @@ new_fact('jboss.eap.deploy-dates',
 new_fact('jboss.eap.installed-versions',
          'List of installed versions of JBoss EAP',
          is_default=False)
+new_fact('jboss.eap.locate-jboss-modules-jar',
+         'Use locate to find jboss-modules.jar',
+         is_default=True)
 new_fact('jboss.eap.jboss-user', "Whether a user called 'jboss' exists",
          is_default=True, categories=[JBOSS_FACTS])
 new_fact('jboss.eap.packages', 'Installed RPMs that look like JBoss',

--- a/roles/jboss_eap/tasks/main.yml
+++ b/roles/jboss_eap/tasks/main.yml
@@ -44,3 +44,8 @@
       register: jboss.eap.packages
       ignore_errors: yes
       when: '"jboss.eap.packages" in facts_to_collect'
+    - name: use locate to look for jboss-modules.jar
+      raw: locate jboss-modules.jar
+      register: jboss_eap_locate_jboss_modules_jar
+      ignore_errors: yes
+      when: '"jboss.eap.locate-jboss-modules-jar" in facts_to_collect'

--- a/test/test_spit_results.py
+++ b/test/test_spit_results.py
@@ -283,3 +283,40 @@ class TestProcessRPMPackages(unittest.TestCase):
         self.assertEqual(results['redhat-packages.gpg.last_installed'], '')
         self.assertIn('redhat-packages.gpg.last_built', results)
         self.assertEqual(results['redhat-packages.gpg.last_built'], '')
+
+
+class TestProcessJbossLocateJbossModulesJar(unittest.TestCase):
+    def run_expect_well_formed(self, output):
+        val = spit_results.process_jboss_eap_locate(
+            [spit_results.JBOSS_EAP_LOCATE_JBOSS_MODULES_JAR],
+            {'jboss_eap_locate_jboss_modules_jar': output})
+
+        self.assertIsInstance(val, dict)
+        self.assertEqual(len(val), 1)
+        self.assertIn(spit_results.JBOSS_EAP_LOCATE_JBOSS_MODULES_JAR, val)
+
+        return val[spit_results.JBOSS_EAP_LOCATE_JBOSS_MODULES_JAR]
+
+    # Most of the error handling is in
+    # spit_results.raw_output_present, which is tested elsewhere, so
+    # we don't need to repeat those tests here.
+
+    def test_success(self):
+        self.assertEqual(
+            self.run_expect_well_formed(
+                {'rc': 0, 'stdout_lines': ['a', 'b', 'c']}),
+            'a;b;c')
+
+    def test_not_found(self):
+        self.assertEqual(
+            self.run_expect_well_formed(
+                {'rc': 1, 'stdout_lines': []}),
+            'jboss-modules.jar not found')
+
+    def test_bad_output(self):
+        self.assertEqual(
+            self.run_expect_well_formed(
+                {'rc': 1, 'stdout': "Command 'locate' not found",
+                 'stdout_lines': ["Command 'locate' not found"]}),
+            "Error code 1 running 'locate jboss-modules.jar': "
+            "Command 'locate' not found")


### PR DESCRIPTION
This lets us scan the whole filesystem (or at least the locate
database) when it's been preindexed.

I've tested it on a test VM that does have jboss-modules.jar and locate installed, and one that does not have either. I've also tried using locate to find a file that doesn't exist, and I made sure that case is covered by unit tests.

Closes #291 .