### PR TITLE
Look for init files related to JBoss EAP

### DIFF
--- a/library/spit_results.py
+++ b/library/spit_results.py
@@ -520,6 +520,77 @@ def process_jboss_eap_locate(fact_names, host_vars):
                 output['rc'], output['stdout'])}
 
 
+JBOSS_EAP_INIT_FILES = 'jboss.eap.init-files'
+
+
+def process_jboss_eap_init_files(fact_names, host_vars):
+    """Look for jboss and EAP in init system output.
+
+    :returns: a dict of key, value pairs to add to the output.
+    """
+
+    # The init system changed between RHEL 6 and RHEL 7. 'chkconfig'
+    # should work on RHEL 6, and 'systemctl list-unit-files' should
+    # work on RHEL 7.
+    err, chkconfig = raw_output_present(fact_names, host_vars,
+                                        JBOSS_EAP_INIT_FILES,
+                                        'jboss_eap_chkconfig',
+                                        'chkconfig')
+    if err is not None:
+        return err
+
+    err, systemctl = raw_output_present(fact_names, host_vars,
+                                        JBOSS_EAP_INIT_FILES,
+                                        'jboss_eap_systemctl_unit_files',
+                                        'systemctl list-unit-files')
+    if err is not None:
+        return err
+
+    if chkconfig['rc'] and systemctl['rc']:
+        return {JBOSS_EAP_INIT_FILES:
+                'Error: all init system checks failed.'}
+
+    # On a RHEL 6 system, chkconfig will return a list of available
+    # services and systemctl will error. On a RHEL 7 system, systemctl
+    # will return a list of system services and chkconfig will return
+    # a shorter list of services and a warning message to go look at
+    # systemctl. However, users may well choose to run JBoss under the
+    # old init system on RHEL 7 due to familiarity or lack of need to
+    # change, so we look in all available output.
+
+    def find_services(lines, method):
+        """Find system services matching 'jboss' or 'eap'
+
+        :returns: a list of the services, as strings, with the method.
+        """
+
+        output = []
+        for line in lines:
+            if not line:
+                continue
+
+            service = line.split()[0]
+            if 'jboss' in service or 'eap' in service:
+                output.append('{0} ({1})'.format(service, method))
+
+        return output
+
+    found_services = []
+    if not chkconfig['rc']:
+        found_services.extend(find_services(chkconfig['stdout_lines'],
+                                            'chkconfig'))
+    if not systemctl['rc']:
+        found_services.extend(find_services(systemctl['stdout_lines'],
+                                            'systemctl'))
+
+    if found_services:
+        return {JBOSS_EAP_INIT_FILES:
+                '; '.join(found_services)}
+
+    return {JBOSS_EAP_INIT_FILES:
+            "No services found matching 'jboss' or 'eap'."}
+
+
 def escape_characters(data):
     """ Processes input data values and strips out any newlines or commas
     """
@@ -775,6 +846,7 @@ class Results(object):
             host_vals.update(process_jboss_eap_processes(keys, host_vars))
             host_vals.update(process_jboss_eap_packages(keys, host_vars))
             host_vals.update(process_jboss_eap_locate(keys, host_vars))
+            host_vals.update(process_jboss_eap_init_files(keys, host_vars))
 
         # Process System ID.
         for data in self.vals:

--- a/rho/facts.py
+++ b/rho/facts.py
@@ -165,6 +165,9 @@ new_fact('jboss.eap.common-files',
 new_fact('jboss.eap.deploy-dates',
          'List of deployment dates of JBoss EAP installations',
          is_default=False)
+new_fact('jboss.eap.init-files',
+         'Find system services that look JBoss-related',
+         is_default=True)
 new_fact('jboss.eap.installed-versions',
          'List of installed versions of JBoss EAP',
          is_default=False)

--- a/roles/jboss_eap/tasks/main.yml
+++ b/roles/jboss_eap/tasks/main.yml
@@ -33,6 +33,7 @@
         - /opt/deploy/jboss/jbossas6/jboss-modules.jar
         - /usr/share/java/jboss-modules.jar
         - /usr/share/jbossas/jboss-modules.jar
+        - /etc/init.d/jboss-as-standalone.sh
       when: '"jboss.eap.common-files" in facts_to_collect'
     - name: gather jboss.eap.processes
       raw: ps -A -f e | grep eap
@@ -49,3 +50,15 @@
       register: jboss_eap_locate_jboss_modules_jar
       ignore_errors: yes
       when: '"jboss.eap.locate-jboss-modules-jar" in facts_to_collect'
+    - name: look for jboss systemd service
+      raw: systemctl list-unit-files
+      register: jboss_eap_systemctl_unit_files
+      ignore_errors: yes
+      become: true
+      when: '"jboss.eap.init-files" in facts_to_collect'
+    - name: look for jboss in chkconfig
+      raw: chkconfig
+      register: jboss_eap_chkconfig
+      ignore_errors: yes
+      become: true
+      when: '"jboss.eap.init-files" in facts_to_collect'


### PR DESCRIPTION
Add another indicator to the JBoss EAP scanning. Now, Rho will look
for init files and system services related to JBoss in addition to
everything else.

Closes #446 .