### PR TITLE
Do postprocessing in main rho process

### DIFF
--- a/rho.spec
+++ b/rho.spec
@@ -47,7 +47,6 @@ install -D -p -m 644 doc/rho.1 $RPM_BUILD_ROOT%{_mandir}/man1/rho.1
 
 mkdir -p %{buildroot}%{_datadir}/ansible/%{name}
 cp rho_playbook.yml %{buildroot}%{_datadir}/ansible/%{name}
-cp -rp library %{buildroot}%{_datadir}/ansible/%{name}/
 cp -rp roles %{buildroot}%{_datadir}/ansible/%{name}/
 
 %clean
@@ -61,7 +60,6 @@ rm -rf $RPM_BUILD_ROOT
 %{_mandir}/man1/rho.1.gz
 %dir %{_datadir}/ansible/%{name}
 %{_datadir}/ansible/%{name}/rho_playbook.yml
-%{_datadir}/ansible/%{name}/library/*
 %{_datadir}/ansible/%{name}/roles/*
 
 %changelog

--- a/rho/ansible_utils.py
+++ b/rho/ansible_utils.py
@@ -84,9 +84,16 @@ def log_yaml_inventory(label, inventory):
     return inventory
 
 
+class AnsibleProcessException(Exception):
+    """Exception raised when an Ansible process fails."""
+
+    pass
+
+
 # pylint: disable=too-many-arguments
 def run_with_vault(cmd_string, vault_pass, env=None, log_path=None,
-                   log_to_stdout=True, ansible_verbosity=0):
+                   log_to_stdout=True, ansible_verbosity=0,
+                   print_before_run=False):
     """Runs ansible command allowing for password to be provided after
     process triggered.
 
@@ -100,6 +107,8 @@ def run_with_vault(cmd_string, vault_pass, env=None, log_path=None,
     :param log_to_stdout: if True, write Ansible's log to stdout. Defaults to
         True.
     :param ansible_verbosity: the number of v's of Ansible verbosity.
+    :param print_before_run: if true, print the command string before running
+        it. Defaults to False.
     :returns: the popen.spawn object for the process.
     """
 
@@ -120,6 +129,8 @@ def run_with_vault(cmd_string, vault_pass, env=None, log_path=None,
             pass
         with open(log_path, 'r+b') as logfile:
             log.debug('Running Ansible: %s', cmd_string)
+            if print_before_run:
+                print('Running:', cmd_string)
             child = pexpect.spawn(cmd_string, timeout=None,
                                   env=env)
 
@@ -156,10 +167,14 @@ def run_with_vault(cmd_string, vault_pass, env=None, log_path=None,
             if log_to_stdout:
                 time.sleep(2)
 
-        return child
     except pexpect.EOF:
         print('Error: unexpected Ansible output')
         sys.exit(1)
     except pexpect.TIMEOUT:
         print('Error: unexpected Ansible output')
         sys.exit(1)
+
+    if child.exitstatus or child.signalstatus:
+        raise AnsibleProcessException(
+            'Ansible process failed with status %s, signal status %s' %
+            (child.exitstatus, child.signalstatus))

--- a/rho/inventory_scan.py
+++ b/rho/inventory_scan.py
@@ -9,12 +9,17 @@
 
 """Scan for software on hosts in an inventory."""
 
+from __future__ import print_function
+
+import csv
 import json
 import os.path
 import sys
+import tempfile
+import time
 
-from rho import ansible_utils, utilities
-from rho.translation import _
+from rho import ansible_utils, postprocessing, utilities
+from rho.translation import _ as t
 from rho.utilities import str_to_ascii
 
 
@@ -78,7 +83,7 @@ def create_main_inventory(vault, hosts, port_map, auth_map, path):
     ansible_utils.log_yaml_inventory('Main inventory', yml_dict)
 
 
-# pylint: disable=too-many-arguments
+# pylint: disable=too-many-arguments, too-many-statements
 def inventory_scan(hosts_yml_path, facts_to_collect, report_path,
                    vault_pass, base_name, forks=None,
                    scan_dirs=None, log_path=None, verbosity=0):
@@ -101,16 +106,21 @@ def inventory_scan(hosts_yml_path, facts_to_collect, report_path,
     hosts_yml = base_name + utilities.PROFILE_HOSTS_SUFIX
     hosts_yml_path = utilities.get_config_path(hosts_yml)
 
+    variables_path = os.path.join(
+        tempfile.gettempdir(),
+        'rho-fact-temp-' + str(time.time()))
+
     ansible_vars = {'facts_to_collect': list(facts_to_collect),
                     'report_path': report_path,
-                    'scan_dirs': ' '.join(scan_dirs or [])}
+                    'scan_dirs': ' '.join(scan_dirs or []),
+                    'variables_path': variables_path}
 
     if os.path.isfile(utilities.PLAYBOOK_DEV_PATH):
         playbook = utilities.PLAYBOOK_DEV_PATH
     elif os.path.isfile(utilities.PLAYBOOK_RPM_PATH):
         playbook = utilities.PLAYBOOK_RPM_PATH
     else:
-        print(_("rho scan playbook not found locally or in '%s'")
+        print(t("rho scan playbook not found locally or in '%s'")
               % playbook)
         sys.exit(1)
 
@@ -125,12 +135,85 @@ def inventory_scan(hosts_yml_path, facts_to_collect, report_path,
 
     log_path = log_path or utilities.SCAN_LOG_PATH
 
-    print('Running:', cmd_string)
+    try:
+        ansible_utils.run_with_vault(
+            cmd_string, vault_pass,
+            log_path=log_path,
+            log_to_stdout=True,
+            ansible_verbosity=verbosity,
+            print_before_run=True)
+    except ansible_utils.AnsibleProcessException as ex:
+        print(t("An error has occurred during the scan. Please review" +
+                " the output to resolve the given issue: %s" % str(ex)))
+        sys.exit(1)
 
-    process = ansible_utils.run_with_vault(
-        cmd_string, vault_pass,
-        log_path=log_path,
-        log_to_stdout=True,
-        ansible_verbosity=verbosity)
+    with open(variables_path, 'r') as variables_file:
+        vars_by_host = json.load(variables_file)
 
-    return process.exitstatus == 0 and process.signalstatus is None
+    # Postprocess Ansible output
+    facts_out = []
+    for _, host_vars in utilities.iteritems(vars_by_host):
+        this_host = {}
+
+        this_host.update(host_vars['connection'])
+        this_host.update(host_vars['cpu'])
+        this_host.update(host_vars['date'])
+        this_host.update(host_vars['dmi'])
+        this_host.update(host_vars['etc_release'])
+        this_host.update(host_vars['file_contents'])
+        this_host.update(host_vars['redhat_packages'])
+        this_host.update(host_vars['redhat_release'])
+        this_host.update(host_vars['subman'])
+        this_host.update(host_vars['uname'])
+        this_host.update(host_vars['virt'])
+        this_host.update(host_vars['virt_what'])
+
+        this_host.update(
+            postprocessing.process_jboss_versions(facts_to_collect, host_vars))
+        this_host.update(
+            postprocessing.process_addon_versions(facts_to_collect, host_vars))
+        this_host.update(
+            postprocessing.process_id_u_jboss(facts_to_collect, host_vars))
+        this_host.update(
+            postprocessing.process_jboss_eap_common_files(
+                facts_to_collect, host_vars))
+        this_host.update(
+            postprocessing.process_jboss_eap_processes(
+                facts_to_collect, host_vars))
+        this_host.update(
+            postprocessing.process_jboss_eap_packages(
+                facts_to_collect, host_vars))
+        this_host.update(
+            postprocessing.process_jboss_eap_locate(
+                facts_to_collect, host_vars))
+        this_host.update(
+            postprocessing.process_jboss_eap_init_files(
+                facts_to_collect, host_vars))
+
+        postprocessing.handle_systemid(facts_to_collect, this_host)
+        postprocessing.handle_redhat_packages(facts_to_collect, this_host)
+        postprocessing.escape_characters(this_host)
+
+        facts_out.append(this_host)
+
+    normalized_path = os.path.normpath(report_path)
+    with open(normalized_path, 'w') as write_file:
+        # Construct the CSV writer
+        writer = csv.DictWriter(
+            write_file, sorted(facts_to_collect), delimiter=',')
+
+        # Write a CSV header if necessary
+        file_size = os.path.getsize(normalized_path)
+        if file_size == 0:
+            # handle Python 2.6 not having writeheader method
+            if sys.version_info[0] == 2 and sys.version_info[1] <= 6:
+                headers = {}
+                for fields in writer.fieldnames:
+                    headers[fields] = fields
+                writer.writerow(headers)
+            else:
+                writer.writeheader()
+
+        # Write the data
+        for data in facts_out:
+            writer.writerow(data)

--- a/rho/postprocessing.py
+++ b/rho/postprocessing.py
@@ -12,6 +12,8 @@
 import sys
 import xml
 
+from rho import utilities
+
 # for parsing systemid
 if sys.version_info > (3,):
     import xmlrpc.client as xmlrpclib  # pylint: disable=import-error
@@ -562,7 +564,7 @@ def escape_characters(data):
     """ Processes input data values and strips out any newlines or commas
     """
     for key in data:
-        if isinstance(data[key], str):
+        if utilities.is_stringlike(data[key]):
             data[key] = data[key].replace('\r\n', ' ').replace(',', ' ')
     return data
 

--- a/rho/postprocessing.py
+++ b/rho/postprocessing.py
@@ -1,5 +1,4 @@
-#
-# Copyright (c) 2009 Red Hat, Inc.
+# Copyright (c) 2017 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,
 # version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -7,19 +6,11 @@
 # FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
 # along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-#
 
-# pylint: disable=R0903
+"""Postprocessing for facts coming from our Ansible playbook."""
 
-"""Module responsible for displaying results of rho report"""
-
-import csv
-import os
-import json
 import sys
 import xml
-# pylint: disable=import-error
-from ansible.module_utils.basic import AnsibleModule
 
 # for parsing systemid
 if sys.version_info > (3,):
@@ -112,30 +103,6 @@ FUSE_CLASSIFICATIONS = {
     'redhat-610379': 'Fuse-6.1.0',
     'redhat-60024': 'Fuse-6.0.0',
 }
-
-
-def iteritems(dictionary):
-    """Iterate over a dictionary's (key, value) pairs using Python 2 or 3.
-
-    :param dictionary: the dictionary to iterate over.
-    """
-
-    if sys.version_info[0] == 2:
-        return dictionary.iteritems()
-
-    return dictionary.items()
-
-
-def safe_next(iterator):
-    """Get the next item from an iterator, in Python 2 or 3.
-
-    :param iterator: the iterator.
-    """
-
-    if sys.version_info[0] == 2:
-        return iterator.next()
-
-    return next(iterator)
 
 
 def raw_output_present(fact_names, host_vars, this_fact, this_var, command):
@@ -788,115 +755,25 @@ class PkgInfoParseException(BaseException):
     pass
 
 
-class Results(object):
-    """The class Results contains the functionality to parse
-    data passed in from the playbook and to output it in the
-    csv format in the file path specified.
+def handle_systemid(fact_names, data):
+    """Process the output of systemid.contents
+    and supply the appropriate output information
     """
+    if 'systemid.contents' in data:
+        blob = data['systemid.contents']
+        id_in_facts = 'SysId_systemid.system_id' in fact_names
+        username_in_facts = 'SysId_systemid.username' in fact_names
+        try:
+            systemid = xmlrpclib.loads(blob)[0][0]
+            if id_in_facts and 'system_id'in systemid:
+                data['systemid.system_id'] = systemid['system_id']
+            if username_in_facts and 'usnername' in systemid:
+                data['systemid.username'] = systemid['usnername']
+        except xml.parsers.expat.ExpatError:
+            if id_in_facts:
+                data['systemid.system_id'] = 'error'
+            if username_in_facts:
+                data['systemid.username'] = 'error'
 
-    def __init__(self, module):
-        self.module = module
-        self.name = module.params['name']
-        self.file_path = module.params['file_path']
-        self.vals = module.params['vals']
-        self.all_vars = module.params['all_vars']
-        self.fact_names = module.params['fact_names']
-
-    def handle_systemid(self, data):
-        """Process the output of systemid.contents
-        and supply the appropriate output information
-        """
-        if 'systemid.contents' in data:
-            blob = data['systemid.contents']
-            id_in_facts = 'SysId_systemid.system_id' in self.fact_names
-            username_in_facts = 'SysId_systemid.username' in self.fact_names
-            try:
-                systemid = xmlrpclib.loads(blob)[0][0]
-                if id_in_facts and 'system_id'in systemid:
-                    data['systemid.system_id'] = systemid['system_id']
-                if username_in_facts and 'usnername' in systemid:
-                    data['systemid.username'] = systemid['usnername']
-            except xml.parsers.expat.ExpatError:
-                if id_in_facts:
-                    data['systemid.system_id'] = 'error'
-                if username_in_facts:
-                    data['systemid.username'] = 'error'
-
-            del data['systemid.contents']
-        return data
-
-    def write_to_csv(self):
-        """Output report data to file in csv format"""
-        # Make sure the controller expanded the default option.
-        assert self.fact_names != ['default']
-
-        keys = set(self.fact_names)
-
-        # Special processing for JBoss facts.
-        for _, host_vars in iteritems(self.all_vars):
-            uuid = host_vars['connection']['connection.uuid']
-            host_vals = safe_next((vals
-                                   for vals in self.vals
-                                   if vals['connection.uuid'] == uuid))
-
-            host_vals.update(process_jboss_versions(keys, host_vars))
-            host_vals.update(process_addon_versions(keys, host_vars))
-            host_vals.update(process_id_u_jboss(keys, host_vars))
-            host_vals.update(process_jboss_eap_common_files(keys, host_vars))
-            host_vals.update(process_jboss_eap_processes(keys, host_vars))
-            host_vals.update(process_jboss_eap_packages(keys, host_vars))
-            host_vals.update(process_jboss_eap_locate(keys, host_vars))
-            host_vals.update(process_jboss_eap_init_files(keys, host_vars))
-
-        # Process System ID.
-        for data in self.vals:
-            data = self.handle_systemid(data)
-            data = handle_redhat_packages(self.fact_names, data)
-            data = escape_characters(data)
-
-        normalized_path = os.path.normpath(self.file_path)
-        with open(normalized_path, 'w') as write_file:
-            # Construct the CSV writer
-            writer = csv.DictWriter(
-                write_file, sorted(keys), delimiter=',')
-
-            # Write a CSV header if necessary
-            file_size = os.path.getsize(normalized_path)
-            if file_size == 0:
-                # handle Python 2.6 not having writeheader method
-                if sys.version_info[0] == 2 and sys.version_info[1] <= 6:
-                    headers = {}
-                    for fields in writer.fieldnames:
-                        headers[fields] = fields
-                    writer.writerow(headers)
-                else:
-                    writer.writeheader()
-
-            # Write the data
-            for data in self.vals:
-                writer.writerow(data)
-
-
-def main():
-    """Function to trigger collection of results and write
-    them to csv file
-    """
-
-    fields = {
-        "name": {"required": True, "type": "str"},
-        "file_path": {"required": True, "type": "str"},
-        "vals": {"required": True, "type": "list"},
-        "all_vars": {"required": True, "type": "dict"},
-        "fact_names": {"required": True, "type": "list"}
-    }
-
-    module = AnsibleModule(argument_spec=fields)
-
-    results = Results(module=module)
-    results.write_to_csv()
-    vals = json.dumps(results.vals)
-    module.exit_json(changed=False, meta=vals)
-
-
-if __name__ == '__main__':
-    main()
+        del data['systemid.contents']
+    return data

--- a/rho/scancommand.py
+++ b/rho/scancommand.py
@@ -280,22 +280,17 @@ class ScanCommand(CliCommand):
                   "Please run without using --cache with the profile first.")
             sys.exit(1)
 
-        scan_succeeded = inventory_scan.inventory_scan(
+        inventory_scan.inventory_scan(
             hosts_yml_path, self.facts_to_collect, report_path, vault_pass,
             profile, forks=forks, scan_dirs=self.options.scan_dirs,
             log_path=self.options.logfile,
             verbosity=self.verbosity)
 
-        if scan_succeeded:
-            host_auth_mapping = \
-                self.options.profile + PROFILE_HOST_AUTH_MAPPING_SUFFIX
-            host_auth_mapping_path = \
-                utilities.get_config_path(host_auth_mapping)
-            print(_("Scanning has completed. The mapping has been"
-                    " stored in file '" + host_auth_mapping_path +
-                    "'. The facts have been stored in '" +
-                    report_path + "'"))
-        else:
-            print(_("An error has occurred during the scan. Please review" +
-                    " the output to resolve the given issue."))
-            sys.exit(1)
+        host_auth_mapping = \
+            self.options.profile + PROFILE_HOST_AUTH_MAPPING_SUFFIX
+        host_auth_mapping_path = \
+            utilities.get_config_path(host_auth_mapping)
+        print(_("Scanning has completed. The mapping has been"
+                " stored in file '" + host_auth_mapping_path +
+                "'. The facts have been stored in '" +
+                report_path + "'"))

--- a/rho/utilities.py
+++ b/rho/utilities.py
@@ -460,7 +460,7 @@ if sys.version_info[0] == 2:
 
         # pylint for python 3 complains that unicode is undefined.
         # pylint: disable=undefined-variable
-        return isinstance(obj, (str, unicode))
+        return isinstance(obj, (str, unicode))  # noqa
 else:
     def is_stringlike(obj):
         """Check if an object is a string.

--- a/rho/utilities.py
+++ b/rho/utilities.py
@@ -458,7 +458,9 @@ if sys.version_info[0] == 2:
         This function is for Python 2 and 3 compatibility.
         """
 
-        return isinstance(obj, str) or isinstance(obj, unicode)
+        # pylint for python 3 complains that unicode is undefined.
+        # pylint: disable=undefined-variable
+        return isinstance(obj, (str, unicode))
 else:
     def is_stringlike(obj):
         """Check if an object is a string.

--- a/rho/utilities.py
+++ b/rho/utilities.py
@@ -451,6 +451,24 @@ def iteritems(dictionary):
     return dictionary.items()
 
 
+if sys.version_info[0] == 2:
+    def is_stringlike(obj):
+        """Check if an object is a string.
+
+        This function is for Python 2 and 3 compatibility.
+        """
+
+        return isinstance(obj, str) or isinstance(obj, unicode)
+else:
+    def is_stringlike(obj):
+        """Check if an object is a string.
+
+        This function is for Python 2 and 3 compatibility.
+        """
+
+        return isinstance(obj, str)
+
+
 def write_csv_data(keys, data, path):
     """ Write csv data with input fieldnames a dictionary of data and the file
     path to write to.

--- a/roles/write/tasks/main.yml
+++ b/roles/write/tasks/main.yml
@@ -1,17 +1,6 @@
 ---
 
-- name: store facts from all hosts in a variable
-  set_fact: host_fact={{hostvars[item]["connection"] | combine(hostvars[item]["uname"]) | combine(hostvars[item]["date"])  | combine(hostvars[item]["file_contents"])  | combine(hostvars[item]["dmi"])  | combine(hostvars[item]["subman"])  | combine(hostvars[item]["redhat_release"])  | combine(hostvars[item]["cpu"])  | combine(hostvars[item]["virt"])  | combine(hostvars[item]["virt_what"])  | combine(hostvars[item]["etc_release"])  | combine(hostvars[item]["redhat_packages"]) }}
-  with_items: "{{groups.alpha}}"
-  register: host_facts
-
-- name: parse variable into a list of dictionaries
-  set_fact: host_facts="{{ host_facts.results | map(attribute="ansible_facts.host_fact") | list }}"
-
-- name: write the list to a csv
-  spit_results:
-    name: reporter
-    file_path: "{{report_path}}"
-    vals: "{{host_facts}}"
-    all_vars: "{{hostvars}}"
-    fact_names: "{{facts_to_collect}}"
+- name: write the host vars to JSON
+  copy:
+    content: "{{hostvars}}"
+    dest: "{{variables_path}}"

--- a/test/test_postprocessing.py
+++ b/test/test_postprocessing.py
@@ -272,3 +272,15 @@ class TestProcessJbossLocateJbossModulesJar(unittest.TestCase):
                  'stdout_lines': ["Command 'locate' not found"]}),
             "Error code 1 running 'locate jboss-modules.jar': "
             "Command 'locate' not found")
+
+
+class TestEscapeCharacters(unittest.TestCase):
+    def test_string(self):
+        data = {'key': 'abc\r\nde,f'}
+        postprocessing.escape_characters(data)
+        self.assertEqual(data['key'], 'abc de f')
+
+    def test_unicode(self):
+        data = {'key': u'abc\r\nde,f'}
+        postprocessing.escape_characters(data)
+        self.assertEqual(data['key'], u'abc de f')

--- a/test/test_postprocessing.py
+++ b/test/test_postprocessing.py
@@ -7,75 +7,24 @@
 # along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
-"""Unit tests for library/spit_results.py."""
+"""Unit tests for fact postprocessing"""
 
-import os
 import unittest
-import mock
-from library import spit_results
+from rho import postprocessing
 
-# pylint: disable=missing-docstring, no-self-use
-
-TMP_TEST_REPORT = "/tmp/test_report.csv"
-
-
-class TestSpitResults(unittest.TestCase):
-
-    def setUp(self):
-        if os.path.isfile(TMP_TEST_REPORT):
-            os.remove(TMP_TEST_REPORT)
-
-    @mock.patch("library.spit_results.AnsibleModule", autospec=True)
-    def test__main__success(self, ansible_mod_cls):
-        mod_obj = ansible_mod_cls.return_value
-        pkg_line = """
-        pciutils|3.5.1|2.el7|1500397509|Red Hat, Inc.|1491250625|
-        x86-038.build.eng.bos.redhat.com|pciutils-3.5.1-2.el7.src.rpm|
-        GPLv2+|Red Hat, Inc. <http://bugzilla.redhat.com/bugzilla>|
-        Tue 18 Jul 2017 01:05:09 PM EDT|Mon 03 Apr 2017 04:17:05 PM EDT|||||
-        """
-        args = {
-            "name": "foo",
-            "file_path": TMP_TEST_REPORT,
-            "vals": [{'connection.uuid': '1',
-                      'systemid.contents': '',
-                      'redhat-packages.results': [pkg_line]}],
-            "all_vars": {'host1':
-                         {'fact1': 'value1',
-                          'fact2': 'value2',
-                          'res': {'fact3': 'value3'},
-                          'connection': {'connection.uuid': '1'},
-                          'jboss.jar-ver':
-                          {'stdout_lines':
-                           ['1.5.4.Final-redhat-1**2017-08-03']}}},
-            "fact_names": ['fact1', 'connection.uuid',
-                           'systemid.username',
-                           'redhat-packages.last_built',
-                           'jboss.deploy-dates', 'jboss.installed-versions']
-        }
-        mod_obj.params = args
-        spit_results.main()
-        expected_arguments_spec = {
-            "name": {"required": True, "type": "str"},
-            "file_path": {"required": True, "type": "str"},
-            "vals": {"required": True, "type": "list"},
-            "all_vars": {"required": True, "type": "dict"},
-            "fact_names": {"required": True, "type": "list"}
-        }
-
-        assert(mock.call(argument_spec=expected_arguments_spec) ==
-               ansible_mod_cls.call_args)
+# pylint: disable=missing-docstring
 
 
 class TestProcessIdUJboss(unittest.TestCase):
-    def run_func(self, output):
-        return spit_results.process_id_u_jboss(
+    @staticmethod
+    def run_func(output):
+        return postprocessing.process_id_u_jboss(
             ['jboss.eap.jboss-user'],
             {'jboss_eap_id_jboss': output})
 
     def test_fact_not_requested(self):
         self.assertEqual(
-            spit_results.process_id_u_jboss([], None),
+            postprocessing.process_id_u_jboss([], None),
             {})
 
     def test_wrongly_skipped(self):
@@ -105,18 +54,19 @@ class TestProcessIdUJboss(unittest.TestCase):
 
 
 class TestProcessJbossCommonFiles(unittest.TestCase):
-    def run_func(self, output):
-        return spit_results.process_jboss_eap_common_files(
+    @staticmethod
+    def run_func(output):
+        return postprocessing.process_jboss_eap_common_files(
             ['jboss.eap.common-files'],
             {'jboss_eap_common_files': output})
 
     def test_fact_not_requested(self):
         self.assertEqual(
-            spit_results.process_jboss_eap_common_files([], {}),
+            postprocessing.process_jboss_eap_common_files([], {}),
             {})
 
     def test_not_in_host_vars(self):
-        res = spit_results.process_jboss_eap_common_files(
+        res = postprocessing.process_jboss_eap_common_files(
             ['jboss.eap.common-files'], {})
 
         self.assertTrue(
@@ -139,8 +89,9 @@ class TestProcessJbossCommonFiles(unittest.TestCase):
 
 
 class TestProcessJbossEapProcesses(unittest.TestCase):
-    def run_func(self, output):
-        return spit_results.process_jboss_eap_processes(
+    @staticmethod
+    def run_func(output):
+        return postprocessing.process_jboss_eap_processes(
             ['jboss.eap.processes'],
             {'jboss.eap.processes': output})
 
@@ -156,8 +107,9 @@ class TestProcessJbossEapProcesses(unittest.TestCase):
 
 
 class TestProcessJbossEapPackages(unittest.TestCase):
-    def run_func(self, output):
-        return spit_results.process_jboss_eap_packages(
+    @staticmethod
+    def run_func(output):
+        return postprocessing.process_jboss_eap_packages(
             ['jboss.eap.packages'],
             {'jboss.eap.packages': output})
 
@@ -205,7 +157,7 @@ class TestProcessRPMPackages(unittest.TestCase):
                  'redhat-packages.gpg.num_rh_packages',
                  'redhat-packages.gpg.last_installed',
                  'redhat-packages.gpg.last_built']
-        results = spit_results.handle_redhat_packages(facts, data)
+        results = postprocessing.handle_redhat_packages(facts, data)
         self.assertIn('redhat-packages.num_installed_packages', results)
         self.assertEqual(results['redhat-packages.num_installed_packages'], 3)
         self.assertIn('redhat-packages.is_redhat', results)
@@ -260,7 +212,7 @@ class TestProcessRPMPackages(unittest.TestCase):
                  'redhat-packages.gpg.num_rh_packages',
                  'redhat-packages.gpg.last_installed',
                  'redhat-packages.gpg.last_built']
-        results = spit_results.handle_redhat_packages(facts, data)
+        results = postprocessing.handle_redhat_packages(facts, data)
         self.assertIn('redhat-packages.num_installed_packages', results)
         self.assertEqual(results['redhat-packages.num_installed_packages'], '')
         self.assertIn('redhat-packages.is_redhat', results)
@@ -287,18 +239,18 @@ class TestProcessRPMPackages(unittest.TestCase):
 
 class TestProcessJbossLocateJbossModulesJar(unittest.TestCase):
     def run_expect_well_formed(self, output):
-        val = spit_results.process_jboss_eap_locate(
-            [spit_results.JBOSS_EAP_LOCATE_JBOSS_MODULES_JAR],
+        val = postprocessing.process_jboss_eap_locate(
+            [postprocessing.JBOSS_EAP_LOCATE_JBOSS_MODULES_JAR],
             {'jboss_eap_locate_jboss_modules_jar': output})
 
         self.assertIsInstance(val, dict)
         self.assertEqual(len(val), 1)
-        self.assertIn(spit_results.JBOSS_EAP_LOCATE_JBOSS_MODULES_JAR, val)
+        self.assertIn(postprocessing.JBOSS_EAP_LOCATE_JBOSS_MODULES_JAR, val)
 
-        return val[spit_results.JBOSS_EAP_LOCATE_JBOSS_MODULES_JAR]
+        return val[postprocessing.JBOSS_EAP_LOCATE_JBOSS_MODULES_JAR]
 
     # Most of the error handling is in
-    # spit_results.raw_output_present, which is tested elsewhere, so
+    # postprocessing.raw_output_present, which is tested elsewhere, so
     # we don't need to repeat those tests here.
 
     def test_success(self):
@@ -320,57 +272,3 @@ class TestProcessJbossLocateJbossModulesJar(unittest.TestCase):
                  'stdout_lines': ["Command 'locate' not found"]}),
             "Error code 1 running 'locate jboss-modules.jar': "
             "Command 'locate' not found")
-
-
-class TestProcessJbossEapInitFiles(unittest.TestCase):
-    def run_func(self, chkconfig, systemctl):
-        val = spit_results.process_jboss_eap_init_files(
-            [spit_results.JBOSS_EAP_INIT_FILES],
-            {'jboss_eap_chkconfig': chkconfig,
-             'jboss_eap_systemctl_unit_files': systemctl})
-
-        self.assertIsInstance(val, dict)
-        self.assertEqual(len(val), 1)
-        self.assertIn(spit_results.JBOSS_EAP_INIT_FILES, val)
-
-        return val[spit_results.JBOSS_EAP_INIT_FILES]
-
-    def test_both_error(self):
-        self.assertEqual(self.run_func({'rc': 1, 'stdout_lines': []},
-                                       {'rc': 1, 'stdout_lines': []}),
-                         'Error: all init system checks failed.')
-
-    def test_just_chkconfig(self):
-        self.assertEqual(
-            self.run_func({'rc': 0,
-                           'stdout_lines': ['foo', 'jboss bar', 'baz']},
-                          {'rc': 1,
-                           'stdout_lines': []}),
-            'jboss (chkconfig)')
-
-    def test_just_systemctl(self):
-        self.assertEqual(
-            self.run_func({'rc': 0,
-                           'stdout_lines': ['foo', 'bar']},
-                          {'rc': 0,
-                           'stdout_lines': ['baz', 'eap narwhal',
-                                            '', 'panda']}),
-            'eap (systemctl)')
-
-    def test_merge_results(self):
-        self.assertEqual(
-            self.run_func({'rc': 0,
-                           'stdout_lines': ['apple', 'bird', 'eap7']},
-                          {'rc': 0,
-                           'stdout_lines': ['puma', 'tiger',
-                                            'jboss-as-standalone']}),
-            'eap7 (chkconfig); '
-            'jboss-as-standalone (systemctl)')
-
-    def test_nothing_found(self):
-        self.assertEqual(
-            self.run_func({'rc': 0,
-                           'stdout_lines': ['Paul', 'George']},
-                          {'rc': 0,
-                           'stdout_lines': ['John', 'Ringo']}),
-            "No services found matching 'jboss' or 'eap'.")


### PR DESCRIPTION
This refactor has several benefits:
  - can share utility functions between postprocessing and the rest of rho
  - can use logging from postprocessing
  - will be able to split postprocessing into different modules in the future

The motiviation for doing it right now is that it also lets us do
multiple Ansible runs in one Rho scan, for instance to find the home
directory of an EAP installation and then run a playbook that depends
on it.

This particular change does not add or remove functionality; it just
moves around code that was already in rho.