### PR TITLE
Detect EAP_HOME directories and Fuse-on-EAP

### DIFF
--- a/doc/facts.rst
+++ b/doc/facts.rst
@@ -29,6 +29,8 @@
 - ``jboss.brms.kie-war-ver`` - KIE runtime version
 - ``jboss.eap.common-files`` - Presence of common files and directories for JBoss EAP
 - ``jboss.eap.deploy-dates`` - List of deployment dates of JBoss EAP installations
+- ``jboss.eap.eap-home`` - Find EAP_HOME directories of JBoss EAP installations
+- ``jboss.eap.init-files`` - Find system services that look JBoss-related
 - ``jboss.eap.installed-versions`` - List of installed versions of JBoss EAP
 - ``jboss.eap.locate-jboss-modules-jar`` - Use locate to find jboss-modules.jar
 - ``jboss.eap.jboss-user`` - Whether a user called 'jboss' exists
@@ -38,6 +40,7 @@
 - ``jboss.fuse.activemq-ver`` - ActiveMQ version
 - ``jboss.fuse.camel-ver`` - Camel version
 - ``jboss.fuse.cxf-ver`` - CXF version
+- ``jboss.fuse.fuse-on-eap`` - Fuse on EAP
 - ``redhat-packages.certs`` - the list of Red Hat certificates found
 - ``redhat-packages.gpg.is_redhat`` - determines if package is a Red Hat package filtered by GPG keys
 - ``redhat-packages.gpg.last_installed`` - last installed package filtered by GPG keys

--- a/rho/facts.py
+++ b/rho/facts.py
@@ -188,7 +188,8 @@ new_fact('jboss.eap.running-paths', 'Paths of running installs of JBoss EAP',
 new_fact('jboss.fuse.activemq-ver', 'ActiveMQ version', is_default=False)
 new_fact('jboss.fuse.camel-ver', 'Camel version', is_default=False)
 new_fact('jboss.fuse.cxf-ver', 'CXF version', is_default=False)
-new_fact('jboss.fuse.fuse-on-eap', 'Fuse on EAP', is_default=True)
+new_fact('jboss.fuse.fuse-on-eap', 'Fuse on EAP',
+         is_default=True, categories=[JBOSS_FACTS])
 new_fact('redhat-packages.certs', 'the list of Red Hat certificates found',
          is_default=True, categories=[RHEL_FACTS])
 new_fact('redhat-packages.gpg.is_redhat',

--- a/rho/facts.py
+++ b/rho/facts.py
@@ -165,6 +165,9 @@ new_fact('jboss.eap.common-files',
 new_fact('jboss.eap.deploy-dates',
          'List of deployment dates of JBoss EAP installations',
          is_default=False)
+new_fact('jboss.eap.eap-home',
+         'Find EAP_HOME directories of JBoss EAP installations',
+         is_default=True, categories=[JBOSS_FACTS])
 new_fact('jboss.eap.init-files',
          'Find system services that look JBoss-related',
          is_default=True)
@@ -185,6 +188,7 @@ new_fact('jboss.eap.running-paths', 'Paths of running installs of JBoss EAP',
 new_fact('jboss.fuse.activemq-ver', 'ActiveMQ version', is_default=False)
 new_fact('jboss.fuse.camel-ver', 'Camel version', is_default=False)
 new_fact('jboss.fuse.cxf-ver', 'CXF version', is_default=False)
+new_fact('jboss.fuse.fuse-on-eap', 'Fuse on EAP', is_default=True)
 new_fact('redhat-packages.certs', 'the list of Red Hat certificates found',
          is_default=True, categories=[RHEL_FACTS])
 new_fact('redhat-packages.gpg.is_redhat',

--- a/rho/inventory_scan.py
+++ b/rho/inventory_scan.py
@@ -189,6 +189,10 @@ def inventory_scan(hosts_yml_path, facts_to_collect, report_path,
         this_host.update(
             postprocessing.process_jboss_eap_init_files(
                 facts_to_collect, host_vars))
+        this_host.update(
+            postprocessing.process_jboss_eap_home(facts_to_collect, host_vars))
+        this_host.update(
+            postprocessing.process_fuse_on_eap(facts_to_collect, host_vars))
 
         postprocessing.handle_systemid(facts_to_collect, this_host)
         postprocessing.handle_redhat_packages(facts_to_collect, this_host)

--- a/roles/jboss_eap/tasks/main.yml
+++ b/roles/jboss_eap/tasks/main.yml
@@ -1,15 +1,68 @@
 
 ---
+
+# Tasks that can locate an EAP_HOME directory
     - name: Gather jboss.eap.running-paths
-      raw: for proc_pid in $(find /proc -maxdepth 1 -xdev -name "[0-9]*"); do ls -l ${proc_pid}/fd 2>/dev/null | grep "java"; done | grep -e "/modules/system/layers/base\|/opt/rh/eap" | sed -n "s/.*\->//p" | sed -n 's/\/modules\/system\/layers\/base.*//p;s/.*\(\/opt\/rh\/eap[1-9]\).*/\1/p' | sort -u
-      register: jboss.eap.running-paths
+      raw: for proc_pid in $(find /proc -maxdepth 1 -xdev -name "[0-9]*"); do ls -l ${proc_pid}/fd 2>/dev/null | grep "java"; done | grep -e "/modules/system/layers/base\|/opt/rh/eap[0-9]/root/usr/share/wildfly" | sed -n "s/.*\-> //p" | sed -n 's/\/modules\/system\/layers\/base.*//p;s/\(.*wildfly\).*/\1/p' | sort -u
+      register: jboss_eap_running_paths
       ignore_errors: yes
-      when: 'have_java and "jboss.eap.running-paths" in facts_to_collect'
-    - name: check for user 'jboss'
-      raw: id -u jboss
-      register: jboss_eap_id_jboss
+      when: 'have_java and ("jboss.eap.running-paths" in facts_to_collect or "jboss.eap.eap-home" in facts_to_collect or "jboss.fuse.fuse-on-eap" in facts_to_collect)'
+
+    - name: use locate to look for jboss-modules.jar
+      raw: locate jboss-modules.jar | xargs -n 1 dirname
+      register: jboss_eap_locate_jboss_modules_jar
       ignore_errors: yes
-      when: '"jboss.eap.jboss-user" in facts_to_collect'
+      when: '"jboss.eap.locate-jboss-modules-jar" in facts_to_collect or "jboss.eap.eap-home" in facts_to_collect or "jboss.fuse.fuse-on-eap" in facts_to_collect'
+
+# Combine the outputs of the above into a single fact
+
+    - name: combine EAP_HOME candidates into single list
+      set_fact:
+        eap_home_candidates: "{{ ((jboss_eap_running_paths['stdout_lines'] if 'stdout_lines' in jboss_eap_running_paths else []) +
+                    (jboss_eap_locate_jboss_modules_jar['stdout_lines'] if 'stdout_lines' in jboss_eap_locate_jboss_modules_jar else [])) | unique}}"
+      ignore_errors: yes
+
+# Filters that will help us find true EAP_HOME directories
+
+    - name: ls EAP_HOME candidates
+      raw: ls -1 "{{ item }}"
+      register: eap_home_candidates_ls
+      ignore_errors: yes
+      with_items: "{{ eap_home_candidates }}"
+      when: '"jboss.eap.eap-home" in facts_to_collect or "jboss.fuse.fuse-on-eap" in facts_to_collect'
+
+    - name: get version.txt from EAP_HOME candidates
+      raw: cat "{{ item }}"/version.txt
+      register: eap_home_candidates_version_txt
+      ignore_errors: yes
+      with_items: "{{ eap_home_candidates }}"
+      when: '"jboss.eap.eap-home" in facts_to_collect or "jboss.fuse.fuse-on-eap" in facts_to_collect'
+
+# Look for fuse inside EAP_HOME directories
+
+    - name: check JBoss bin directory
+      raw: ls -1 "{{ item }}"/bin
+      register: eap_home_candidates_bin
+      ignore_errors: yes
+      with_items: "{{ eap_home_candidates }}"
+      when: '"jboss.fuse.fuse-on-eap" in facts_to_collect'
+
+    - name: check JBoss layers.conf
+      raw: cat "{{ item }}"/modules/layers.conf
+      register: eap_home_candidates_layers_conf
+      ignore_errors: yes
+      with_items: "{{ eap_home_candidates }}"
+      when: '"jboss.fuse.fuse-on-eap" in facts_to_collect'
+
+    - name: check JBoss modules/system/layers
+      raw: ls -1 "{{ item }}"/modules/system/layers
+      register: eap_home_candidates_layers
+      ignore_errors: yes
+      with_items: "{{ eap_home_candidates }}"
+      when: '"jboss.fuse.fuse-on-eap" in facts_to_collect'
+
+# Tests that can indicate the presence of EAP, but don't let us
+# automatically locate EAP_HOME
     - name: check for common install files and directories
       raw: test -e "{{ item }}"
       register: jboss_eap_common_files
@@ -45,11 +98,11 @@
       register: jboss.eap.packages
       ignore_errors: yes
       when: '"jboss.eap.packages" in facts_to_collect'
-    - name: use locate to look for jboss-modules.jar
-      raw: locate jboss-modules.jar
-      register: jboss_eap_locate_jboss_modules_jar
+    - name: check for user 'jboss'
+      raw: id -u jboss
+      register: jboss_eap_id_jboss
       ignore_errors: yes
-      when: '"jboss.eap.locate-jboss-modules-jar" in facts_to_collect'
+      when: '"jboss.eap.jboss-user" in facts_to_collect'
     - name: look for jboss systemd service
       raw: systemctl list-unit-files
       register: jboss_eap_systemctl_unit_files

--- a/test/test_postprocessing.py
+++ b/test/test_postprocessing.py
@@ -274,6 +274,64 @@ class TestProcessJbossLocateJbossModulesJar(unittest.TestCase):
             "Command 'locate' not found")
 
 
+class TestProcessJbossEapHome(unittest.TestCase):
+    def test_one_dir(self):
+        ls_result = [
+            'appclient', 'docs', 'installation', 'LICENSE.txt', 'standalone',
+            'welcome-content', 'bin', 'domain', 'JBossEULA.txt', 'modules',
+            'Uninstaller', 'bundles', 'icons', 'jboss-modules.jar',
+            'SHA256SUM', 'version.txt']
+        cat_result = (
+            'Red Hat JBoss Enterprise Application Platform - Version 6.4.0.GA')
+
+        result = postprocessing.process_jboss_eap_home(
+            [postprocessing.JBOSS_EAP_EAP_HOME],
+            {'eap_home_candidates_ls': {
+                'results': [
+                    {'item': 'eap_home', 'rc': 0,
+                     'stdout_lines': ls_result}]},
+             'eap_home_candidates_version_txt': {
+                 'results': [
+                     {'item': 'eap_home', 'rc': 0,
+                      'stdout': cat_result}]}})
+
+        self.assertIn(postprocessing.JBOSS_EAP_EAP_HOME, result)
+        dir_result = result[postprocessing.JBOSS_EAP_EAP_HOME]
+
+        # pylint: disable=line-too-long
+        self.assertEqual(dir_result,
+                         'eap_home: eap_home contains appclient,standalone,JBossEULA.txt,modules,jboss-modules.jar,version.txt, Red Hat JBoss Enterprise Application Platform - Version 6.4.0.GA')  # noqa
+
+
+class TestProcessFuseOnEap(unittest.TestCase):
+    def test_success(self):
+        ls_bin = ['fuseconfig.sh', 'fusepatch.sh']
+        layers_conf = '#Tue Oct 24 16:22:35 EDT 2017\nlayers=fuse,soa\n'
+        ls_layers = ['base', 'fuse', 'soa']
+
+        result = postprocessing.process_fuse_on_eap(
+            [postprocessing.JBOSS_FUSE_FUSE_ON_EAP],
+            {'eap_home_candidates_bin': {
+                'results': [
+                    {'item': 'eap_home', 'rc': 0,
+                     'stdout_lines': ls_bin}]},
+             'eap_home_candidates_layers_conf': {
+                 'results': [
+                     {'item': 'eap_home', 'rc': 0,
+                      'stdout': layers_conf}]},
+             'eap_home_candidates_layers': {
+                 'results': [
+                     {'item': 'eap_home', 'rc': 0,
+                      'stdout_lines': ls_layers}]}})
+
+        self.assertIn(postprocessing.JBOSS_FUSE_FUSE_ON_EAP, result)
+        dir_result = result[postprocessing.JBOSS_FUSE_FUSE_ON_EAP]
+
+        # pylint: disable=line-too-long
+        self.assertEqual(dir_result,
+                         'eap_home: /bin=eap_home contains fuseconfig.sh,fusepatch.sh, /modules/layers.conf=#Tue Oct 24 16:22:35 EDT 2017\nlayers=fuse,soa, /modules/system/layers=eap_home contains fuse')  # noqa
+
+
 class TestEscapeCharacters(unittest.TestCase):
     def test_string(self):
         data = {'key': 'abc\r\nde,f'}


### PR DESCRIPTION
Modify roles/jboss_eap/tasks/main.yml to detect EAP_HOME directories,
and add new tasks to look inside of the EAP_HOME directories for
indicators that Fuse-on-EAP is installed. Also add postprocessing for
the new results, and new fact names to trigger all of the above.

Note that we're starting to see some blowup in the when clauses in
that playbook. It's fixable, I just didn't want to do that fix in this
commit. Filed #464 to track it.

Closes #428 . Closes #462 .