### PR TITLE
Add jboss.eap.init-files to group 'jboss'

### DIFF
--- a/rho/facts.py
+++ b/rho/facts.py
@@ -170,7 +170,7 @@ new_fact('jboss.eap.eap-home',
          is_default=True, categories=[JBOSS_FACTS])
 new_fact('jboss.eap.init-files',
          'Find system services that look JBoss-related',
-         is_default=True)
+         is_default=True, categories=[JBOSS_FACTS])
 new_fact('jboss.eap.installed-versions',
          'List of installed versions of JBoss EAP',
          is_default=False)


### PR DESCRIPTION
I should have added it to the group when I added the fact; this is
correcting an oversight.

Closes #466 .