### PR TITLE
Handle missing facts better

### DIFF
--- a/rho/postprocessing.py
+++ b/rho/postprocessing.py
@@ -810,8 +810,10 @@ UNKNOWN_BASE = 'unknown base directory'
 def process_brms_output(fact_names, host_vars):
     """Process facts for jboss.brms."""
 
-    business_central_candidates = host_vars['business_central_candidates']
-    kie_server_candidates = host_vars['kie_server_candidates']
+    business_central_candidates = host_vars.get(
+        'business_central_candidates', [])
+    kie_server_candidates = host_vars.get(
+        'kie_server_candidates', [])
 
     err, manifest_mf_out = raw_output_present(
         fact_names, host_vars,

--- a/roles/brms/tasks/main.yml
+++ b/roles/brms/tasks/main.yml
@@ -28,6 +28,7 @@
         kie_server_candidates_eap: "{{ kie_server_candidates_eap + [item + '/standalone/deployments/kie-server.war'] }}"
       when: 'eap_home_candidates is defined'
       with_items: "{{ eap_home_candidates }}"
+      when: '"jboss.brms" in facts_to_collect'
 
     - name: combine special directory candidates into single list
       set_fact:


### PR DESCRIPTION
Add a missing 'when' clause, and modify a postprocessing step to
handle missing facts (which would happen if a fact wasn't requested).

Closes #511 .