### PR TITLE
Add facts to find JBoss Fuse

### DIFF
--- a/doc/facts.rst
+++ b/doc/facts.rst
@@ -31,6 +31,7 @@
 - ``jboss.eap.common-files`` - Presence of common files and directories for JBoss EAP
 - ``jboss.eap.deploy-dates`` - List of deployment dates of JBoss EAP installations
 - ``jboss.eap.eap-home`` - Find EAP_HOME directories of JBoss EAP installations
+- ``jboss.eap.find-jboss-modules-jar`` - Use the find command to find jboss-modules.jar
 - ``jboss.eap.init-files`` - Find system services that look JBoss-related
 - ``jboss.eap.installed-versions`` - List of installed versions of JBoss EAP
 - ``jboss.eap.locate-jboss-modules-jar`` - Use locate to find jboss-modules.jar
@@ -38,11 +39,13 @@
 - ``jboss.eap.packages`` - Installed RPMs that look like JBoss
 - ``jboss.eap.processes`` - Running processes that look like JBoss
 - ``jboss.eap.running-paths`` - Paths of running installs of JBoss EAP
-- ``jboss.fuse.activemq-ver`` - ActiveMQ version
-- ``jboss.fuse.camel-ver`` - Camel version
-- ``jboss.fuse.cxf-ver`` - CXF version
+- ``jboss.eap.summary`` - Summary of JBoss EAP information
+- ``jboss.activemq-ver`` - ActiveMQ version
+- ``jboss.camel-ver`` - Camel version
+- ``jboss.cxf-ver`` - CXF version
 - ``jboss.fuse.fuse-on-eap`` - Fuse on EAP
 - ``jboss.fuse.init-files`` - Fuse-related init files
+- ``jboss.fuse-on-karaf.find-karaf-jar`` - Use the find utility to locate karaf.jar
 - ``jboss.fuse-on-karaf.karaf-home`` - Karaf home
 - ``redhat-packages.certs`` - the list of Red Hat certificates found
 - ``redhat-packages.gpg.is_redhat`` - determines if package is a Red Hat package filtered by GPG keys

--- a/rho/facts.py
+++ b/rho/facts.py
@@ -170,6 +170,9 @@ new_fact('jboss.eap.deploy-dates',
 new_fact('jboss.eap.eap-home',
          'Find EAP_HOME directories of JBoss EAP installations',
          is_default=True, categories=[JBOSS_FACTS])
+new_fact('jboss.eap.find-jboss-modules-jar',
+         'Use the find command to find jboss-modules.jar',
+         is_default=False)
 new_fact('jboss.eap.init-files',
          'Find system services that look JBoss-related',
          is_default=True, categories=[JBOSS_FACTS])
@@ -189,13 +192,16 @@ new_fact('jboss.eap.running-paths', 'Paths of running installs of JBoss EAP',
          is_default=True, categories=[JBOSS_FACTS])
 new_fact('jboss.eap.summary', 'Summary of JBoss EAP information',
          is_default=True, categories=[JBOSS_FACTS])
-new_fact('jboss.fuse.activemq-ver', 'ActiveMQ version', is_default=False)
-new_fact('jboss.fuse.camel-ver', 'Camel version', is_default=False)
-new_fact('jboss.fuse.cxf-ver', 'CXF version', is_default=False)
+new_fact('jboss.activemq-ver', 'ActiveMQ version', is_default=False)
+new_fact('jboss.camel-ver', 'Camel version', is_default=False)
+new_fact('jboss.cxf-ver', 'CXF version', is_default=False)
 new_fact('jboss.fuse.fuse-on-eap', 'Fuse on EAP',
          is_default=True, categories=[JBOSS_FACTS])
 new_fact('jboss.fuse.init-files', 'Fuse-related init files',
          is_default=True, categories=[JBOSS_FACTS])
+new_fact('jboss.fuse-on-karaf.find-karaf-jar',
+         'Use the find utility to locate karaf.jar',
+         is_default=False)
 new_fact('jboss.fuse-on-karaf.karaf-home', 'Karaf home',
          is_default=True, categories=[JBOSS_FACTS])
 new_fact('redhat-packages.certs', 'the list of Red Hat certificates found',

--- a/rho/inventory_scan.py
+++ b/rho/inventory_scan.py
@@ -204,11 +204,16 @@ def inventory_scan(hosts_yml_path, facts_to_collect, report_path,
                 facts_to_collect, host_vars))
         this_host.update(
             postprocessing.process_brms_output(facts_to_collect, host_vars))
+        this_host.update(postprocessing.process_find_jboss_modules_jar(
+            facts_to_collect, host_vars))
+        this_host.update(postprocessing.process_find_karaf_jar(
+            facts_to_collect, host_vars))
 
         postprocessing.handle_systemid(facts_to_collect, this_host)
         postprocessing.handle_redhat_packages(facts_to_collect, this_host)
         postprocessing.escape_characters(this_host)
-        this_host.update(postprocessing.generate_eap_summary(this_host))
+        this_host.update(postprocessing.generate_eap_summary(
+            facts_to_collect, this_host))
 
         # After all of the facts have been generated, remove -mr facts
         # which were for machine use only.

--- a/rho/postprocessing.py
+++ b/rho/postprocessing.py
@@ -303,9 +303,9 @@ def process_addon_versions(fact_names, host_vars):
     classify('jboss.brms.drools-core-ver', fact_names, BRMS_CLASSIFICATIONS)
     classify('jboss.brms.kie-war-ver', fact_names, BRMS_CLASSIFICATIONS)
 
-    classify('jboss.fuse.activemq-ver', fact_names, FUSE_CLASSIFICATIONS)
-    classify('jboss.fuse.camel-ver', fact_names, FUSE_CLASSIFICATIONS)
-    classify('jboss.fuse.cxf-ver', fact_names, FUSE_CLASSIFICATIONS)
+    classify('jboss.activemq-ver', fact_names, FUSE_CLASSIFICATIONS)
+    classify('jboss.camel-ver', fact_names, FUSE_CLASSIFICATIONS)
+    classify('jboss.cxf-ver', fact_names, FUSE_CLASSIFICATIONS)
 
     return result
 
@@ -680,8 +680,11 @@ def process_jboss_eap_home(fact_names, host_vars):
 JBOSS_EAP_SUMMARY = 'jboss.eap.summary'
 
 
-def generate_eap_summary(facts):
+def generate_eap_summary(facts_to_collect, facts):
     """Generate a single summary fact about whether the machine has EAP."""
+
+    if JBOSS_EAP_SUMMARY not in facts_to_collect:
+        return {}
 
     installed_versions = facts.get(JBOSS_EAP_INSTALLED_VERSIONS + MR)
     deploy_dates = facts.get(JBOSS_EAP_DEPLOY_DATES + MR)
@@ -711,6 +714,44 @@ def generate_eap_summary(facts):
                 'Maybe - an EAP installation may be present'}
 
     return {JBOSS_EAP_SUMMARY: 'No EAP installation detected'}
+
+
+JBOSS_EAP_FIND_JBOSS_MODULES_JAR = 'jboss.eap.find-jboss-modules-jar'
+
+
+def process_find_jboss_modules_jar(fact_names, host_vars):
+    """Process the output of 'find jboss-modules.jar'"""
+
+    if JBOSS_EAP_FIND_JBOSS_MODULES_JAR not in fact_names:
+        return {}
+
+    err, out = raw_output_present(fact_names, host_vars,
+                                  JBOSS_EAP_FIND_JBOSS_MODULES_JAR,
+                                  'jboss_eap_find_jboss_modules_jar',
+                                  'find jboss-modules.jar')
+    if err is not None:
+        return err
+
+    return {JBOSS_EAP_FIND_JBOSS_MODULES_JAR: '; '.join(out['stdout_lines'])}
+
+
+FIND_KARAF_JAR = 'jboss.fuse-on-karaf.find-karaf-jar'
+
+
+def process_find_karaf_jar(fact_names, host_vars):
+    """Process the output of 'find karaf.jar'"""
+
+    if FIND_KARAF_JAR not in fact_names:
+        return {}
+
+    err, out = raw_output_present(fact_names, host_vars,
+                                  FIND_KARAF_JAR,
+                                  'karaf_find_karaf_jar',
+                                  'find karaf.jar')
+    if err is not None:
+        return err
+
+    return {FIND_KARAF_JAR: '; '.join(out['stdout_lines'])}
 
 
 JBOSS_FUSE_FUSE_ON_EAP = 'jboss.fuse.fuse-on-eap'

--- a/roles/fuse/tasks/main.yml
+++ b/roles/fuse/tasks/main.yml
@@ -1,20 +1,20 @@
 
 ---
 # This will scan linux systems for JBoss Fuse, ActiveMQ, CXF, Camel or Community  Installations
-    - name: Gather jboss.fuse.activemq-ver
+    - name: Gather jboss.activemq-ver
       raw: FOUND=""; for jar in `find {{scan_dirs}} -type f -xdev -name \*activemq-\*redhat\*.jar 2>/dev/null | sed -n 's/.*\(redhat-[0-9]\{6\}\).*/\1/p' | sort -u`; do if [ ! -z "${jar}" ]; then if [ ! -z "$FOUND" ]; then FOUND="$FOUND; $jar"; else FOUND=${jar}; fi; fi; done; echo ${FOUND}
-      register: jboss.fuse.activemq-ver
+      register: jboss.activemq-ver
       ignore_errors: yes
-      when: '"jboss.fuse.activemq-ver" in facts_to_collect'
+      when: '"jboss.activemq-ver" in facts_to_collect'
 
-    - name: Gather jboss.fuse.camel-ver
+    - name: Gather jboss.camel-ver
       raw: FOUND=""; for jar in `find {{scan_dirs}} -type f -xdev -name \*camel-core\*redhat\*.jar 2>/dev/null | sed -n 's/.*\(redhat-[0-9]\{6\}\).*/\1/p' | sort -u`; do if [ ! -z "${jar}" ]; then if [ ! -z "$FOUND" ]; then FOUND="$FOUND; $jar"; else FOUND=${jar}; fi; fi; done; echo ${FOUND}
-      register: jboss.fuse.camel-ver
+      register: jboss.camel-ver
       ignore_errors: yes
-      when: '"jboss.fuse.camel-ver" in facts_to_collect'
+      when: '"jboss.camel-ver" in facts_to_collect'
 
-    - name: Gather jboss.fuse.cxf-ver
+    - name: Gather jboss.cxf-ver
       raw: FOUND=""; for jar in `find {{scan_dirs}} -type f -xdev -name \*cxf-rt\*redhat\*.jar 2>/dev/null | sed -n 's/.*\(redhat-[0-9]\{6\}\).*/\1/p' | sort -u`; do if [ ! -z "${jar}" ]; then if [ ! -z "$FOUND" ]; then FOUND="$FOUND; $jar"; else FOUND=${jar}; fi; fi; done; echo ${FOUND}
-      register: jboss.fuse.cxf-ver
+      register: jboss.cxf-ver
       ignore_errors: yes
-      when: '"jboss.fuse.cxf-ver" in facts_to_collect'
+      when: '"jboss.cxf-ver" in facts_to_collect'

--- a/roles/jboss_eap/tasks/main.yml
+++ b/roles/jboss_eap/tasks/main.yml
@@ -14,12 +14,19 @@
       ignore_errors: yes
       when: 'have_locate and ("jboss.eap.locate-jboss-modules-jar" in facts_to_collect or "jboss.eap.eap-home" in facts_to_collect or "jboss.fuse.fuse-on-eap" in facts_to_collect)'
 
+    - name: use find to look for jboss-modules.jar
+      raw: find {{scan_dirs}} -xdev -type f -name jboss-modules.jar 2> /dev/null | xargs -n 1 dirname 2> /dev/null | sort -u
+      register: jboss_eap_find_jboss_modules_jar
+      ignore_errors: yes
+      when: '"jboss.eap.find-jboss-modules-jar" in facts_to_collect'
+
 # Combine the outputs of the above into a single fact
 
     - name: combine EAP_HOME candidates into single list
       set_fact:
         eap_home_candidates: "{{ ((jboss_eap_running_paths['stdout_lines'] if 'stdout_lines' in jboss_eap_running_paths else []) +
-                    (jboss_eap_locate_jboss_modules_jar['stdout_lines'] if 'stdout_lines' in jboss_eap_locate_jboss_modules_jar else [])) | unique}}"
+                    (jboss_eap_locate_jboss_modules_jar['stdout_lines'] if 'stdout_lines' in jboss_eap_locate_jboss_modules_jar else []) +
+                    jboss_eap_find_jboss_modules_jar.get('stdout_lines', [])) | unique}}"
       ignore_errors: yes
 
 # Filters that will help us find true EAP_HOME directories

--- a/roles/jboss_fuse_on_karaf/tasks/main.yml
+++ b/roles/jboss_fuse_on_karaf/tasks/main.yml
@@ -42,12 +42,19 @@
       ignore_errors: yes
       when: 'have_locate and "jboss.fuse-on-karaf.karaf-home" in facts_to_collect'
 
+    - name: Use find to look for karaf.jar
+      raw: find {{scan_dirs}} -xdev -type f -name karaf.jar 2> /dev/null | sed -n -e 's/\(.*\)lib\/karaf\.jar$/\1/p' | xargs -n 1 realpath  2> /dev/null | sort -u
+      register: karaf_find_karaf_jar
+      ignore_errors: yes
+      when: '"jboss.fuse-on-karaf.find-karaf-jar" in facts_to_collect'
+
 # Combine the outputs of the above into a single fact
 
     - name: combine KARAF_HOME candidates into single list
       set_fact:
           karaf_homes: "{{ (karaf_running_processes.get('stdout_lines', []) +
-                            karaf_locate_karaf_jar.get('stdout_lines', [])) | unique }}"
+                            karaf_locate_karaf_jar.get('stdout_lines', []) +
+                            karaf_find_karaf_jar.get('stdout_lines', [])) | unique }}"
       ignore_errors: yes
       when: '"jboss.fuse-on-karaf.karaf-home" in facts_to_collect'
 


### PR DESCRIPTION
Add two new facts to use 'find' to locate JBoss Fuse if the user
requests it. Also rename some old facts whose names implied they would
find JBoss Fuse but would in fact not.

Sending this to dev instead of master because despite the merges yesterday, it looks like there's some code in dev that is not in master for reasons I don't understand. I can merge dev into master again after this.

Closes #284 .