### PR TITLE
Make raw_output_present always return data if data is present

### DIFF
--- a/rho/inventory_scan.py
+++ b/rho/inventory_scan.py
@@ -228,7 +228,8 @@ def inventory_scan(hosts_yml_path, facts_to_collect, report_path,
     with open(normalized_path, 'w') as write_file:
         # Construct the CSV writer
         writer = csv.DictWriter(
-            write_file, sorted(facts_to_collect), delimiter=',')
+            write_file, sorted(facts_to_collect), delimiter=',',
+            extrasaction='ignore')
 
         # Write a CSV header if necessary
         file_size = os.path.getsize(normalized_path)

--- a/rho/postprocessing.py
+++ b/rho/postprocessing.py
@@ -136,10 +136,10 @@ def raw_output_present(fact_names, host_vars, this_fact, this_var, command):
         ... process output ...
     """
 
-    if this_fact not in fact_names:
-        return {}, None
-
     if this_var not in host_vars:
+        if this_fact not in fact_names:
+            return {}, None
+
         return {this_fact: 'Error: "{0}" not run'.format(command)}, None
 
     raw_output = host_vars[this_var]

--- a/test/test_postprocessing.py
+++ b/test/test_postprocessing.py
@@ -22,6 +22,9 @@ class TestProcessIdUJboss(unittest.TestCase):
             ['jboss.eap.jboss-user'],
             {'jboss_eap_id_jboss': output})
 
+    # Disable this test due to issue/541. Should be re-enabled when
+    # that issue has a more permanent solution.
+    @unittest.skip
     def test_fact_not_requested(self):
         self.assertEqual(
             postprocessing.process_id_u_jboss([], None),


### PR DESCRIPTION
Move `if` clause so that `raw_output_present` always returns data if data is present.

This requires temporarily disabling a test which checked for the old behavior. Also add `extrasaction='ignore'` to the `DictWriter` so that it won't error if we pass it extra columns because of this change.

Closes #541 .