### PR TITLE
Issues/544

### DIFF
--- a/rho/facts.py
+++ b/rho/facts.py
@@ -225,18 +225,6 @@ new_fact('redhat-packages.gpg.num_rh_packages',
 new_fact('redhat-packages.gpg.num_installed_packages',
          'number of installed packages filtered by GPG keys',
          is_default=True, categories=[RHEL_FACTS])
-new_fact('redhat-packages.is_redhat',
-         'determines if package is a Red Hat package',
-         is_default=True, categories=[RHEL_FACTS])
-new_fact('redhat-packages.last_installed', 'last installed package',
-         is_default=True, categories=[RHEL_FACTS])
-new_fact('redhat-packages.last_built', 'last built package',
-         is_default=True, categories=[RHEL_FACTS])
-new_fact('redhat-packages.num_rh_packages', 'number of Red Hat packages',
-         is_default=True, categories=[RHEL_FACTS])
-new_fact('redhat-packages.num_installed_packages',
-         'number of installed packages',
-         is_default=True, categories=[RHEL_FACTS])
 new_fact('redhat-release.name',
          "name of package that provides 'redhat-release'",
          is_default=True, categories=[RHEL_FACTS])

--- a/rho/postprocessing.py
+++ b/rho/postprocessing.py
@@ -1122,6 +1122,14 @@ def determine_pkg_facts(rh_packages):
     return is_red_hat, last_installed_val, last_built_val
 
 
+PREFIX = 'redhat-packages.gpg.'
+IS_REDHAT = PREFIX + 'is_redhat'
+NUM_RH = PREFIX + 'num_rh_packages'
+INSTALLED_PKG = PREFIX + 'num_installed_packages'
+LAST_INSTALLED = PREFIX + 'last_installed'
+LAST_BUILT = PREFIX + 'last_built'
+
+
 # pylint: disable=too-many-locals, too-many-branches, too-many-statements
 def handle_redhat_packages(facts, data):
     """ Process the output of redhat-packages.results
@@ -1130,19 +1138,6 @@ def handle_redhat_packages(facts, data):
     if 'redhat-packages.results' not in data:
         return
 
-    rhpkg_prefix = 'redhat-packages.'
-    gpg_prefix = rhpkg_prefix + 'gpg.'
-    gpg_is_rhpkg_str = gpg_prefix + 'is_redhat'
-    gpg_num_rh_str = gpg_prefix + 'num_rh_packages'
-    gpg_installed_pkg_str = gpg_prefix + 'num_installed_packages'
-    gpg_last_installed_str = gpg_prefix + 'last_installed'
-    gpg_last_built_str = gpg_prefix + 'last_built'
-    gpg_is_rhpkg_in_facts = gpg_is_rhpkg_str in facts
-    gpg_num_rh_in_facts = gpg_num_rh_str in facts
-    gpg_installed_pkg_in_facts = gpg_installed_pkg_str in facts
-    gpg_last_installed_in_facts = gpg_last_installed_str in facts
-    gpg_last_built_in_facts = gpg_last_built_str in facts
-    installed_packages = None
     try:
         installed_packages = [PkgInfo(line, "|")
                               for line in data['redhat-packages.results']]
@@ -1150,25 +1145,25 @@ def handle_redhat_packages(facts, data):
         # facts are already initialized as empty strings
         # just remove the results field
         del data['redhat-packages.results']
-        return data
+        return
 
     rh_gpg_packages = list(filter(PkgInfo.is_gpg_red_hat_pkg,
                                   installed_packages))
 
-    if gpg_installed_pkg_in_facts:
-        data[gpg_installed_pkg_str] = (len(installed_packages))
-    if gpg_num_rh_in_facts:
-        data[gpg_num_rh_str] = len(rh_gpg_packages)
+    if INSTALLED_PKG in facts:
+        data[INSTALLED_PKG] = (len(installed_packages))
+    if NUM_RH in facts:
+        data[NUM_RH] = len(rh_gpg_packages)
 
     if rh_gpg_packages:
         is_red_hat, last_installed, last_built = \
             determine_pkg_facts(rh_gpg_packages)
-        if gpg_is_rhpkg_in_facts:
-            data[gpg_is_rhpkg_str] = is_red_hat
-        if gpg_last_installed_in_facts:
-            data[gpg_last_installed_str] = last_installed
-        if gpg_last_built_in_facts:
-            data[gpg_last_built_str] = last_built
+        if IS_REDHAT in facts:
+            data[IS_REDHAT] = is_red_hat
+        if LAST_INSTALLED in facts:
+            data[LAST_INSTALLED] = last_installed
+        if LAST_BUILT:
+            data[LAST_BUILT] = last_built
 
     del data['redhat-packages.results']
 
@@ -1217,14 +1212,7 @@ class PkgInfo(object):
                 if self.is_red_hat_gpg:
                     break
 
-            # Helper methods to help with recording data in
-            # requested fields.
-
-    def is_red_hat_pkg(self):
-        """Determines if package is a Red Hat package.
-        :returns: True if Red Hat, False otherwise
-        """
-        return self.is_red_hat
+    # Helper methods to help with recording data in requested fields.
 
     def is_gpg_red_hat_pkg(self):
         """Determines if package is a Red Hat package with known GPG key.

--- a/rho/postprocessing.py
+++ b/rho/postprocessing.py
@@ -1152,30 +1152,13 @@ def handle_redhat_packages(facts, data):
         del data['redhat-packages.results']
         return data
 
-    rh_packages = list(filter(PkgInfo.is_red_hat_pkg,
-                              installed_packages))
-
     rh_gpg_packages = list(filter(PkgInfo.is_gpg_red_hat_pkg,
                                   installed_packages))
 
-    if installed_pkg_in_facts:
-        data[installed_pkg_str] = (len(installed_packages))
-    if num_rh_in_facts:
-        data[num_rh_str] = len(rh_packages)
     if gpg_installed_pkg_in_facts:
         data[gpg_installed_pkg_str] = (len(installed_packages))
     if gpg_num_rh_in_facts:
         data[gpg_num_rh_str] = len(rh_gpg_packages)
-
-    if rh_packages:
-        is_red_hat, last_installed, last_built = \
-            determine_pkg_facts(rh_packages)
-        if is_rhpkg_in_facts:
-            data[is_rhpkg_str] = is_red_hat
-        if last_installed_in_facts:
-            data[last_installed_str] = last_installed
-        if last_built_in_facts:
-            data[last_built_str] = last_built
 
     if rh_gpg_packages:
         is_red_hat, last_installed, last_built = \

--- a/roles/redhat_packages/tasks/main.yml
+++ b/roles/redhat_packages/tasks/main.yml
@@ -4,26 +4,6 @@
   set_fact:
     redhat_packages: "{{ redhat_packages|default({}) }}"
 
-- name: set gather_is_redhat fact
-  set_fact:
-    gather_is_redhat: "{{ 'redhat-packages.is_redhat' in facts_to_collect }}"
-
-- name: set gather_num_rh_packages fact
-  set_fact:
-    gather_num_rh_packages: "{{ 'redhat-packages.num_rh_packages' in facts_to_collect }}"
-
-- name: set gather_num_installed_packages fact
-  set_fact:
-    gather_num_installed_packages: "{{ 'redhat-packages.num_installed_packages' in facts_to_collect }}"
-
-- name: set gather_last_installed fact
-  set_fact:
-    gather_last_installed: "{{ 'redhat-packages.last_installed' in facts_to_collect }}"
-
-- name: set gather_last_built fact
-  set_fact:
-    gather_last_built: "{{ 'redhat-packages.last_built' in facts_to_collect }}"
-
 - name: set gather_is_redhat_gpg fact
   set_fact:
     gather_is_redhat_gpg: "{{ 'redhat-packages.gpg.is_redhat' in facts_to_collect }}"
@@ -44,52 +24,9 @@
   set_fact:
     gather_last_built_gpg: "{{ 'redhat-packages.gpg.last_built' in facts_to_collect }}"
 
-- name: set gather_certs fact
-  set_fact:
-    gather_certs: "{{ 'redhat-packages.certs' in facts_to_collect }}"
-
-- name: set gather_redhat_packages fact
-  set_fact:
-    gather_redhat_packages: "{{ gather_is_redhat or gather_num_rh_packages or gather_num_installed_packages or gather_last_installed or gather_last_built }}"
-
 - name: set gather_redhat_packages_gpg fact
   set_fact:
     gather_redhat_packages_gpg: "{{ gather_is_redhat_gpg or gather_num_rh_packages_gpg or gather_num_installed_packages_gpg or gather_last_installed_gpg or gather_last_built_gpg }}"
-
-- name: initialize redhat-packages.is_redhat to dictionary
-  set_fact:
-    redhat_packages: "{{ redhat_packages|default({}) | combine({ item: '' }) }}"
-  with_items:
-  - 'redhat-packages.is_redhat'
-  when: gather_is_redhat
-
-- name: initialize redhat-packages.num_rh_packages to dictionary
-  set_fact:
-    redhat_packages: "{{ redhat_packages|default({}) | combine({ item: '' }) }}"
-  with_items:
-  - 'redhat-packages.num_rh_packages'
-  when: gather_num_rh_packages
-
-- name: initialize redhat-packages.num_installed_packages to dictionary
-  set_fact:
-    redhat_packages: "{{ redhat_packages|default({}) | combine({ item: '' }) }}"
-  with_items:
-  - 'redhat-packages.num_installed_packages'
-  when: gather_num_installed_packages
-
-- name: initialize redhat-packages.last_installed to dictionary
-  set_fact:
-    redhat_packages: "{{ redhat_packages|default({}) | combine({ item: '' }) }}"
-  with_items:
-  - 'redhat-packages.last_installed'
-  when: gather_last_installed
-
-- name: initialize redhat-packages.last_built to dictionary
-  set_fact:
-    redhat_packages: "{{ redhat_packages|default({}) | combine({ item: '' }) }}"
-  with_items:
-  - 'redhat-packages.last_built'
-  when: gather_last_built
 
 - name: initialize redhat-packages.gpg.is_redhat to dictionary
   set_fact:
@@ -130,14 +67,18 @@
   raw: rpm -qa --qf "%{NAME}|%{VERSION}|%{RELEASE}|%{INSTALLTIME}|%{VENDOR}|%{BUILDTIME}|%{BUILDHOST}|%{SOURCERPM}|%{LICENSE}|%{PACKAGER}|%{INSTALLTIME:date}|%{BUILDTIME:date}|%{DSAHEADER:pgpsig}|%{RSAHEADER:pgpsig}|%{SIGGPG:pgpsig}|%{SIGPGP:pgpsig}|\n"
   register: redhat_packages_results
   ignore_errors: yes
-  when: have_rpm and (gather_redhat_packages or gather_redhat_packages_gpg)
+  when: have_rpm and gather_redhat_packages_gpg
 
 - name: add redhat-packages.results to dictionary
   set_fact:
     redhat_packages: "{{ redhat_packages|default({}) | combine({ item: redhat_packages_results['stdout_lines'] | default([]) if have_rpm else 'N/A (rpm not found)' }) }}"
   with_items:
   - 'redhat-packages.results'
-  when: gather_redhat_packages
+  when: gather_redhat_packages_gpg
+
+- name: set gather_certs fact
+  set_fact:
+    gather_certs: "{{ 'redhat-packages.certs' in facts_to_collect }}"
 
 - name: initialize redhat-packages.certs fact
   set_fact:

--- a/test/test_postprocessing.py
+++ b/test/test_postprocessing.py
@@ -146,104 +146,52 @@ class TestProcessRPMPackages(unittest.TestCase):
                     ["ghc-semigroups|0.8.5|3.el7|1506981888|Fedora Project|1480663695|buildhw-09.phx2.fedoraproject.org|ghc-semigroups-0.8.5-3.el7.src.rpm|BSD|Fedora Project|Mon 02 Oct 2017 06:04:48 PM EDT|Fri 02 Dec 2016 02:28:15 AM EST|(none)|RSA/SHA256, Fri 09 Dec 2016 01:17:53 AM EST, Key ID 6a2faea2352c64e5|(none)|RSA/SHA256, Fri 09 Dec 2016 01:17:53 AM EST, Key ID 6a2faea2352c64e5|",  # noqa: E501
                      "dhclient|4.2.5|58.el7|1500397510|Red Hat, Inc.|1494940069|x86-030.build.eng.bos.redhat.com|dhcp-4.2.5-58.el7.src.rpm|ISC|Red Hat, Inc. <http://bugzilla.redhat.com/bugzilla>|Tue 18 Jul 2017 01:05:10 PM EDT|Tue 16 May 2017 09:07:49 AM EDT|(none)|RSA/SHA256, Tue 16 May 2017 09:40:41 AM EDT, Key ID 199e2f91fd431d51|(none)|RSA/SHA256, Tue 16 May 2017 09:40:40 AM EDT, Key ID 199e2f91fd431d51|",  # noqa: E501
                      "setup|2.8.71|7.el7|1500397469|Red Hat, Inc.|1462364954|arm64-018.build.eng.bos.redhat.com|setup-2.8.71-7.el7.src.rpm|Public Domain|Red Hat, Inc. <http://bugzilla.redhat.com/bugzilla>|Tue 18 Jul 2017 01:04:29 PM EDT|Wed 04 May 2016 08:29:14 AM EDT|(none)|RSA/SHA256, Fri 23 Sep 2016 06:55:43 AM EDT, Key ID 199e2f91fd431d51|(none)|RSA/SHA256, Fri 23 Sep 2016 06:55:43 AM EDT, Key ID 199e2f91fd431d51|"],  # noqa: E501
-                'redhat-packages.num_installed_packages': '',
-                'redhat-packages.is_redhat': '',
-                'redhat-packages.num_rh_packages': '',
-                'redhat-packages.last_installed': '',
-                'redhat-packages.last_built': '',
                 'redhat-packages.gpg.num_installed_packages': '',
                 'redhat-packages.gpg.is_redhat': '',
                 'redhat-packages.gpg.num_rh_packages': '',
                 'redhat-packages.gpg.last_installed': '',
                 'redhat-packages.gpg.last_built': ''}
-        facts = ['redhat-packages.num_installed_packages',
-                 'redhat-packages.is_redhat',
-                 'redhat-packages.num_rh_packages',
-                 'redhat-packages.last_installed',
-                 'redhat-packages.last_built',
-                 'redhat-packages.gpg.num_installed_packages',
+        facts = ['redhat-packages.gpg.num_installed_packages',
                  'redhat-packages.gpg.is_redhat',
                  'redhat-packages.gpg.num_rh_packages',
                  'redhat-packages.gpg.last_installed',
                  'redhat-packages.gpg.last_built']
-        results = postprocessing.handle_redhat_packages(facts, data)
-        self.assertIn('redhat-packages.num_installed_packages', results)
-        self.assertEqual(results['redhat-packages.num_installed_packages'], 3)
-        self.assertIn('redhat-packages.is_redhat', results)
-        self.assertEqual(results['redhat-packages.is_redhat'], 'Y')
-        self.assertIn('redhat-packages.num_rh_packages', results)
-        self.assertEqual(results['redhat-packages.num_rh_packages'], 2)
-        self.assertIn('redhat-packages.last_installed', results)
-        self.assertEqual(results['redhat-packages.last_installed'],
-                         'dhclient-4.2.5-58.el7 Installed: Tue 18'
-                         ' Jul 2017 01:05:10 PM EDT')
-        self.assertIn('redhat-packages.last_built', results)
-        self.assertEqual(results['redhat-packages.last_built'],
-                         'dhclient-4.2.5-58.el7 Built: Tue 16 May'
-                         ' 2017 09:07:49 AM EDT')
 
-        self.assertIn('redhat-packages.gpg.num_installed_packages', results)
-        self.assertEqual(results['redhat-packages.gpg.num_installed_packages'],
-                         3)
-        self.assertIn('redhat-packages.gpg.is_redhat', results)
-        self.assertEqual(results['redhat-packages.gpg.is_redhat'], 'Y')
-        self.assertIn('redhat-packages.gpg.num_rh_packages', results)
-        self.assertEqual(results['redhat-packages.gpg.num_rh_packages'], 2)
-        self.assertIn('redhat-packages.gpg.last_installed', results)
-        self.assertEqual(results['redhat-packages.gpg.last_installed'],
+        postprocessing.handle_redhat_packages(facts, data)
+
+        self.assertEqual(
+            data.get('redhat-packages.gpg.num_installed_packages'), 3)
+        self.assertEqual(data.get('redhat-packages.gpg.is_redhat'), 'Y')
+        self.assertEqual(data.get('redhat-packages.gpg.num_rh_packages'), 2)
+        self.assertEqual(data.get('redhat-packages.gpg.last_installed'),
                          'dhclient-4.2.5-58.el7 Installed: Tue 18'
                          ' Jul 2017 01:05:10 PM EDT')
-        self.assertIn('redhat-packages.gpg.last_built', results)
-        self.assertEqual(results['redhat-packages.gpg.last_built'],
+        self.assertEqual(data.get('redhat-packages.gpg.last_built'),
                          'dhclient-4.2.5-58.el7 Built: Tue 16 May'
                          ' 2017 09:07:49 AM EDT')
 
     def test_rpm_packages_no_rpm(self):
         data = {'redhat-packages.results': 'N/A (rpm not found)',
-                'redhat-packages.num_installed_packages': '',
-                'redhat-packages.is_redhat': '',
-                'redhat-packages.num_rh_packages': '',
-                'redhat-packages.last_installed': '',
-                'redhat-packages.last_built': '',
                 'redhat-packages.gpg.num_installed_packages': '',
                 'redhat-packages.gpg.is_redhat': '',
                 'redhat-packages.gpg.num_rh_packages': '',
                 'redhat-packages.gpg.last_installed': '',
                 'redhat-packages.gpg.last_built': ''}
 
-        facts = ['redhat-packages.num_installed_packages',
-                 'redhat-packages.is_redhat',
-                 'redhat-packages.num_rh_packages',
-                 'redhat-packages.last_installed',
-                 'redhat-packages.last_built',
-                 'redhat-packages.gpg.num_installed_packages',
+        facts = ['redhat-packages.gpg.num_installed_packages',
                  'redhat-packages.gpg.is_redhat',
                  'redhat-packages.gpg.num_rh_packages',
                  'redhat-packages.gpg.last_installed',
                  'redhat-packages.gpg.last_built']
-        results = postprocessing.handle_redhat_packages(facts, data)
-        self.assertIn('redhat-packages.num_installed_packages', results)
-        self.assertEqual(results['redhat-packages.num_installed_packages'], '')
-        self.assertIn('redhat-packages.is_redhat', results)
-        self.assertEqual(results['redhat-packages.is_redhat'], '')
-        self.assertIn('redhat-packages.num_rh_packages', results)
-        self.assertEqual(results['redhat-packages.num_rh_packages'], '')
-        self.assertIn('redhat-packages.last_installed', results)
-        self.assertEqual(results['redhat-packages.last_installed'], '')
-        self.assertIn('redhat-packages.last_built', results)
-        self.assertEqual(results['redhat-packages.last_built'], '')
 
-        self.assertIn('redhat-packages.gpg.num_installed_packages', results)
-        self.assertEqual(results['redhat-packages.gpg.num_installed_packages'],
-                         '')
-        self.assertIn('redhat-packages.gpg.is_redhat', results)
-        self.assertEqual(results['redhat-packages.gpg.is_redhat'], '')
-        self.assertIn('redhat-packages.gpg.num_rh_packages', results)
-        self.assertEqual(results['redhat-packages.gpg.num_rh_packages'], '')
-        self.assertIn('redhat-packages.gpg.last_installed', results)
-        self.assertEqual(results['redhat-packages.gpg.last_installed'], '')
-        self.assertIn('redhat-packages.gpg.last_built', results)
-        self.assertEqual(results['redhat-packages.gpg.last_built'], '')
+        postprocessing.handle_redhat_packages(facts, data)
+
+        self.assertEqual(
+            data.get('redhat-packages.gpg.num_installed_packages'), '')
+        self.assertEqual(data.get('redhat-packages.gpg.is_redhat'), '')
+        self.assertEqual(data.get('redhat-packages.gpg.num_rh_packages'), '')
+        self.assertEqual(data.get('redhat-packages.gpg.last_installed'), '')
+        self.assertEqual(data.get('redhat-packages.gpg.last_built'), '')
 
 
 class TestProcessJbossLocateJbossModulesJar(unittest.TestCase):


### PR DESCRIPTION
Remove redundant `redhat-packages.....` facts, now that the GPG method has proven to be useful.

This PR also includes some minor cleanups to the postprocessing code for those facts.

Closes #544 .